### PR TITLE
Hide noisy logs by default

### DIFF
--- a/server/core/schedule_task.go
+++ b/server/core/schedule_task.go
@@ -106,7 +106,7 @@ func scheduleAndTrackNextTaskRun(app *App, ctx context.Context, taskID string, c
 		app.Logger.WithGroup("tasks").Error("Error inserting next run time into DB", slog.Any("error", err), slog.String("task", taskID))
 		return
 	}
-	app.Logger.WithGroup("tasks").Info("Scheduled task", slog.String("task", taskID), slog.Time("next", *nextRunAt))
+	app.Logger.WithGroup("tasks").Debug("Scheduled task", slog.String("task", taskID), slog.Time("next", *nextRunAt))
 }
 
 // Schedule a timer, then publish task to NATS.

--- a/server/web/web.go
+++ b/server/web/web.go
@@ -44,7 +44,18 @@ func Start(
 	e.HidePort = true
 
 	// Middlewares
-	e.Use(slogecho.New(app.Logger.WithGroup("web")))
+	e.Use(slogecho.NewWithFilters(
+		app.Logger.WithGroup("web"),
+		slogecho.Accept(func(ctx echo.Context) bool {
+			path := ctx.Request().URL.Path
+			// Always log API requests
+			if strings.HasPrefix(path, "/api/") {
+				// Only log non-API requests if debug level is enabled
+				return app.Logger.Enabled(ctx.Request().Context(), slog.LevelDebug)
+			}
+			return true
+		}),
+	))
 	e.Use(middleware.BodyLimit("2M"))
 	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{Level: 5}))
 	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{


### PR DESCRIPTION
Non /api requests and tasks run should not be logged by default.
They create noise. Use log level debug if you like to see them.