### PR TITLE
Add flag --duckdb-secret-dir

### DIFF
--- a/server/snapshots/restore.go
+++ b/server/snapshots/restore.go
@@ -149,6 +149,13 @@ func restoreDuckDBSnapshot(ctx context.Context, duckdbPath string, config Config
 		}
 	}
 
+	if config.DuckDBSecretDir != "" {
+		_, err := tempDB.Exec("SET secret_directory = ?", config.DuckDBSecretDir)
+		if err != nil {
+			return fmt.Errorf("failed to set DuckDB secret directory: %w", err)
+		}
+	}
+
 	if config.InitSQL != "" {
 		// Substitute environment variables in the SQL
 		sql, err := prepSQL(config.InitSQL)

--- a/server/snapshots/snapshots.go
+++ b/server/snapshots/snapshots.go
@@ -30,6 +30,7 @@ type Config struct {
 	DuckDB          *sqlx.DB
 	Nats            *nats.Conn
 	DuckDBExtDir    string
+	DuckDBSecretDir string
 	InitSQL         string
 	InitSQLFile     string
 	S3Bucket        string


### PR DESCRIPTION
Change the default directory where persistent secrets are stored.

Note that we are not overriding the default in Docker like we do for extensions since this is potentially a breaking change if someone uses persistent secrets in Docker.

I would like to do that change in the future though. 