### PR TITLE
Fix: Date Range Picker - Select a single value

### DIFF
--- a/ui/src/components/dashboard/DashboardDateRangePicker.tsx
+++ b/ui/src/components/dashboard/DashboardDateRangePicker.tsx
@@ -128,6 +128,12 @@ function DashboardDateRangePicker ({
               const toDateString = `${value.to.getFullYear()}-${value.to.toLocaleDateString("en-US", { month: "2-digit" })}-${value.to.toLocaleDateString("en-US", { day: "2-digit" })}`;
               varsCopy[toVarName] = toDateString;
             }
+            if (value.from === undefined && value.to !== undefined) {
+              varsCopy[fromVarName] = varsCopy[toVarName];
+            }
+            if (value.to === undefined && value.from !== undefined) {
+              varsCopy[toVarName] = varsCopy[fromVarName];
+            }
             onChange(varsCopy);
           }}
           className={"min-w-40 my-1"}


### PR DESCRIPTION
When selecting a single value (only "from", not "to"), show data for that day.

Before, the other value was set to the default value which could also be in the past and results in not showing any data