### PR TITLE
Set id attributes on dashboards

### DIFF
--- a/ui/src/components/charts/ChartDownloadButton.tsx
+++ b/ui/src/components/charts/ChartDownloadButton.tsx
@@ -13,12 +13,14 @@ interface ChartDownloadButtonProps {
   chartId: string;
   label?: string;
   className?: string;
+  id?: string;
 }
 
 export const ChartDownloadButton: React.FC<ChartDownloadButtonProps> = ({
   chartId,
   label,
   className,
+  id,
 }) => {
   const { isDarkMode } = React.useContext(DarkModeContext);
   const handleDownload = React.useCallback(() => {
@@ -55,6 +57,7 @@ export const ChartDownloadButton: React.FC<ChartDownloadButtonProps> = ({
         )}
         onClick={handleDownload}
         title={translate("Save as image")}
+        id={id}
       >
         <RiDownload2Line className="size-4" />
       </button>

--- a/ui/src/components/dashboard/DashboardButton.tsx
+++ b/ui/src/components/dashboard/DashboardButton.tsx
@@ -6,6 +6,7 @@ import { Button } from "../tremor/Button";
 import { Label } from "../tremor/Label";
 import { useState } from "react";
 import { cx } from "../../lib/utils";
+import { toCssId } from "../../lib/render";
 
 type ButtonProps = {
   label?: string;
@@ -13,6 +14,7 @@ type ButtonProps = {
   data: Result["sections"][0]["queries"][0]["rows"];
   baseUrl?: string;
   getJwt: () => Promise<string>;
+  idPrefix: string;
 };
 
 function DashboardButton ({
@@ -21,6 +23,7 @@ function DashboardButton ({
   headers,
   baseUrl,
   getJwt,
+  idPrefix,
 }: ButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
 
@@ -69,6 +72,7 @@ function DashboardButton ({
         className={cx("my-1 select-none print:hidden", {
           "ml-2": !label,
         })}
+        id={toCssId(`${idPrefix}${label ? `${label}-` : ""}${headers[0].name}`)}
       >
         <span className="flex items-center justify-between">
           {headers[0].name}

--- a/ui/src/components/dashboard/DashboardDatePicker.tsx
+++ b/ui/src/components/dashboard/DashboardDatePicker.tsx
@@ -5,6 +5,7 @@ import { DatePicker } from "../tremor/DatePicker";
 import { Label } from "../tremor/Label";
 import { cx, getLocalDate } from "../../lib/utils";
 import { translate } from "../../lib/translate";
+import { toCssId } from "../../lib/render";
 
 type PickerProps = {
   label?: string;
@@ -12,6 +13,7 @@ type PickerProps = {
   data: (string | number | boolean)[][];
   onChange: (newVars: Record<string, string | string[]>) => void;
   vars?: Record<string, string | string[]>;
+  idPrefix: string;
 };
 
 function DashboardDatePicker ({
@@ -20,6 +22,7 @@ function DashboardDatePicker ({
   headers,
   onChange,
   vars,
+  idPrefix,
 }: PickerProps) {
   const defaultValueIndex = headers.findIndex((header) => header.tag === "default");
   if (defaultValueIndex === -1) {
@@ -36,7 +39,7 @@ function DashboardDatePicker ({
       {label && <Label htmlFor={label} className="ml-3 pr-1 print:hidden">{label}:</Label>}
       <div className={cx("select-none print:hidden", { ["ml-2"]: !label })}>
         <DatePicker
-          id={label}
+          id={toCssId(`${idPrefix}${varName}`)}
           defaultValue={typeof defaultValue === "boolean" || !defaultValue ? undefined : getLocalDate(defaultValue)}
           enableYearNavigation
           value={selectedDate ? getLocalDate(selectedDate) : undefined}

--- a/ui/src/components/dashboard/DashboardDateRangePicker.tsx
+++ b/ui/src/components/dashboard/DashboardDateRangePicker.tsx
@@ -5,6 +5,7 @@ import { DateRangePicker } from "../tremor/DatePicker";
 import { Label } from "../tremor/Label";
 import { cx, getLocalDate } from "../../lib/utils";
 import { translate } from "../../lib/translate";
+import { toCssId } from "../../lib/render";
 
 type PickerProps = {
   label?: string;
@@ -12,6 +13,7 @@ type PickerProps = {
   data: (string | number | boolean)[][];
   onChange: (newVars: Record<string, string | string[]>) => void;
   vars?: Record<string, string | string[]>;
+  idPrefix: string;
 };
 
 function DashboardDateRangePicker ({
@@ -20,6 +22,7 @@ function DashboardDateRangePicker ({
   headers,
   onChange,
   vars,
+  idPrefix,
 }: PickerProps) {
   const defaultFromValue = headers.findIndex((header) => header.tag === "defaultFrom");
   if (defaultFromValue === -1) {
@@ -98,7 +101,7 @@ function DashboardDateRangePicker ({
       {label && <Label htmlFor={label} className="ml-3 pr-1 print:hidden">{label}:</Label>}
       <div className={cx("select-none print:hidden", { ["ml-2"]: !label })}>
         <DateRangePicker
-          id={label}
+          id={toCssId(`${idPrefix}${fromVarName}`)}
           presets={presets}
           enableYearNavigation
           placeholder={translate("Select date range")}

--- a/ui/src/components/dashboard/DashboardDropdown.tsx
+++ b/ui/src/components/dashboard/DashboardDropdown.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { Column } from "../../lib/types";
-import { formatValue } from "../../lib/render";
+import { formatValue, toCssId } from "../../lib/render";
 import {
   Select,
   SelectContent,
@@ -20,6 +20,7 @@ type DropdownProps = {
   data: (string | number | boolean)[][];
   onChange: (newVars: Record<string, string | string[]>) => void;
   vars?: Record<string, string | string[]>;
+  idPrefix: string;
 };
 
 function DashboardDropdown ({
@@ -28,6 +29,7 @@ function DashboardDropdown ({
   headers,
   onChange,
   vars,
+  idPrefix,
 }: DropdownProps) {
   const valueIndex = headers.findIndex((header) => header.tag === "value");
   const labelIndex = headers.findIndex((header) => header.tag === "label");
@@ -56,7 +58,7 @@ function DashboardDropdown ({
           ).toString() || EMPTY}
         >
           <SelectTrigger
-            id={label}
+            id={toCssId(`${idPrefix}${varName}`)}
             className="mx-auto my-1 data-[state=open]:bg-cbga data-[state=open]:dark:bg-dbga"
           >
             <SelectValue />

--- a/ui/src/components/dashboard/DashboardDropdownMulti.tsx
+++ b/ui/src/components/dashboard/DashboardDropdownMulti.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "../tremor/DropdownMenu";
-import { formatValue } from "../../lib/render";
+import { formatValue, toCssId } from "../../lib/render";
 import { translate } from "../../lib/translate";
 
 type DropdownProps = {
@@ -20,6 +20,7 @@ type DropdownProps = {
   data: (string | number | boolean)[][];
   onChange: (newVars: Record<string, string | string[]>) => void;
   vars?: Record<string, string | string[]>;
+  idPrefix: string;
 };
 
 function DashboardDropdownMulti ({
@@ -28,6 +29,7 @@ function DashboardDropdownMulti ({
   headers,
   onChange,
   vars,
+  idPrefix,
 }: DropdownProps) {
   const valueIndex = headers.findIndex((header) => header.tag === "value");
   const labelIndex = headers.findIndex((header) => header.tag === "label");
@@ -58,6 +60,7 @@ function DashboardDropdownMulti ({
           <Button
             variant="secondary"
             className="flex w-full items-center justify-between my-1 data-[state=open]:bg-cbga data-[state=open]:dark:bg-dbga"
+            id={toCssId(`${idPrefix}${varName}`)}
           >
             {label ?? varName} (
             {noneSelected ? 0 : selectedValArr.length || data.length})

--- a/ui/src/components/dashboard/DashboardInput.tsx
+++ b/ui/src/components/dashboard/DashboardInput.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { Column } from "../../lib/types";
-import { formatValue } from "../../lib/render";
+import { formatValue, toCssId } from "../../lib/render";
 import { Input } from "../tremor/Input";
 import { Label } from "../tremor/Label";
 import { cx } from "../../lib/utils";
@@ -14,6 +14,7 @@ type InputProps = {
   data: (string | number | boolean)[][];
   onChange: (newVars: Record<string, string | string[]>) => void;
   vars?: Record<string, string | string[]>;
+  idPrefix: string;
 };
 
 function DashboardInput ({
@@ -22,6 +23,7 @@ function DashboardInput ({
   headers,
   onChange,
   vars,
+  idPrefix,
 }: InputProps) {
   const valueIndex = headers.findIndex((header) => header.tag === "hint");
   const varName = headers[valueIndex].name;
@@ -55,7 +57,7 @@ function DashboardInput ({
       )}
       <div className={cx("print:hidden", { ["ml-2"]: !label })}>
         <Input
-          id={label}
+          id={toCssId(`${idPrefix}${varName}`)}
           value={localValue}
           placeholder={placeholder}
           onChange={(e) => {

--- a/ui/src/components/dashboard/index.tsx
+++ b/ui/src/components/dashboard/index.tsx
@@ -2,6 +2,7 @@
 
 import { ErrorBoundary } from "react-error-boundary";
 import { Result } from "../../lib/types";
+import { toCssId } from "../../lib/render";
 import { ChartHoverProvider } from "../providers/ChartHoverProvider";
 import { cx, getSearchParamString, VarsParamSchema } from "../../lib/utils";
 import DashboardDropdown from "./DashboardDropdown";
@@ -222,6 +223,7 @@ const DataView = ({
         return (
           <section
             key={sectionIndex}
+            id={toCssId(`header${sectionIndex}`)}
             className={cx("flex flex-wrap items-center ml-2 mr-4", {
               "mt-3 mb-3": section.queries.length > 0 || section.title,
               "mt-8": section.title && sectionIndex !== 0,
@@ -253,6 +255,7 @@ const DataView = ({
                 return (
                   <DashboardDropdown
                     key={index}
+                    idPrefix={`header${sectionIndex}-${render.type}-`}
                     label={render.label}
                     headers={columns}
                     data={rows}
@@ -265,6 +268,7 @@ const DataView = ({
                 return (
                   <DashboardDropdownMulti
                     key={index}
+                    idPrefix={`header${sectionIndex}-${render.type}-`}
                     label={render.label}
                     headers={columns}
                     data={rows}
@@ -277,6 +281,7 @@ const DataView = ({
                 return (
                   <DashboardButton
                     key={index}
+                    idPrefix={`header${sectionIndex}-${render.type}-`}
                     label={render.label}
                     headers={columns}
                     data={rows}
@@ -289,6 +294,7 @@ const DataView = ({
                 return (
                   <DashboardDatePicker
                     key={index}
+                    idPrefix={`header${sectionIndex}-${render.type}-`}
                     label={render.label}
                     headers={columns}
                     data={rows}
@@ -301,6 +307,7 @@ const DataView = ({
                 return (
                   <DashboardDateRangePicker
                     key={index}
+                    idPrefix={`header${sectionIndex}-${render.type}-`}
                     label={render.label}
                     headers={columns}
                     data={rows}
@@ -313,6 +320,7 @@ const DataView = ({
                 return (
                   <DashboardInput
                     key={index}
+                    idPrefix={`header${sectionIndex}-${render.type}-`}
                     label={render.label}
                     headers={columns}
                     data={rows}
@@ -333,6 +341,7 @@ const DataView = ({
       return (
         <section
           key={sectionIndex}
+          id={toCssId(`content${sectionIndex}`)}
           className={cx("grid grid-cols-1 ml-4", {
             "@sm:grid-cols-2 print:grid-cols-2": numQueriesInSection > 1,
             "@sm:grid-cols-3 print:grid-cols-3":
@@ -360,9 +369,11 @@ const DataView = ({
             }
             const isChartQuery = query.render.type === "linechart" || query.render.type === "gauge" || query.render.type.startsWith("barchart") || query.render.type.startsWith("boxplot");
             const singleTable = numQueriesInSection === 1 && query.render.type === "table";
+            const cardCssId = query.render.label || `${query.render.type}${queryIndex}`;
             return (
               <Card
                 key={queryIndex}
+                id={toCssId(`content${sectionIndex}-${cardCssId}`)}
                 className={cx(
                   "mr-4 mb-4 bg-cbgs dark:bg-dbgs border-none shadow-sm flex flex-col group break-inside-avoid",
                   {
@@ -381,6 +392,7 @@ const DataView = ({
                     chartId={`${sectionIndex}-${queryIndex}`}
                     label={query.render.label}
                     className="absolute top-2 right-2 z-40"
+                    id={toCssId(`content${sectionIndex}-${cardCssId}-download-button`)}
                   />
                 ) : query.render.label && (
                   <h2 className="text-md pb-4 mx-4 text-center font-semibold font-display">

--- a/ui/src/lib/render.ts
+++ b/ui/src/lib/render.ts
@@ -118,3 +118,15 @@ export const isJSONType = (columnType: Column["type"]) => {
 export const echartsEncode = (v: string | number) => {
   return echarts.format.encodeHTML(v.toString());
 };
+
+export function toCssId (v: string | number) {
+  return "shaper-" + (v.toString()
+    // Replace spaces and special characters with hyphens
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    // Remove consecutive hyphens
+    .replace(/-+/g, "-")
+    // Remove leading/trailing hyphens
+    .replace(/^-+|-+$/g, "")
+    // Handle empty string case
+    || Math.random().toString(36).substring(2, 10)).toLowerCase();
+}

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-/** @type {import('tailwindcss').Config} */
 import defaultTheme from 'tailwindcss/defaultTheme';
 import { scopedPreflightStyles, isolateInsideOfContainer } from 'tailwindcss-scoped-preflight';
 import containerQueries from '@tailwindcss/container-queries';
 
+/** @type {import('tailwindcss').Config} */
 export default {
   content: [
     "ui/index.html",


### PR DESCRIPTION
This is helpful when using a behavioral analytics tool to have fixed identifiers to attach events to.

It allows tracking button clicks, scroll, hover, ...

IDs are generated from titles/labels and falling back to index if not set.

Setting for the following:
- each section
- each card
- each filter and button
- chart download buttons

<img width="334" height="296" alt="Screenshot_20251120_141049" src="https://github.com/user-attachments/assets/8e2c7a5b-4c42-4863-a5df-0f0a57f66545" />
