### PR TITLE
Full URLs in download links

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func buildRootCommand(ctx context.Context) *ff.Command {
 	tlsEmail := flags.StringLong("tls-email", "", "Email address for Let's Encrypt registration (optional, used for alerting about certificate expiration)")
 	tlsCache := flags.StringLong("tls-cache", "", "Path to Let's Encrypt cache directory (default: [--dir]/letsencrypt-cache)")
 	httpsHost := flags.StringLong("https-port", "", "Overwrite https hostname to not listen on all interfaces")
-	basePath := flags.StringLong("basepath", "/", "Base URL path the frontend is served from. Override if you are using a reverse proxy and serve the frontend from a subpath.")
+	basePath := flags.StringLong("basepath", "/", "Base URL the frontend is served from. Override if you are using a reverse proxy and serve the frontend from a subpath. Can be a path starting with a slash or a full URL. If you want to use the download API with mode=url, you also have to set basepath to a full URL, otherwise URLs will be relative only. Does not apply if tls-domain set")
 	pdfDateFormat := flags.StringLong("pdf-date-format", "02.01.2006", "Date format for PDF exports, using Go time format, examples: '2006-01-02', '01/02/2006', '02.01.2006', 'Jan 2, 2006'")
 	natsHost := flags.StringLong("nats-host", "0.0.0.0", "NATS server host")
 	natsPort := flags.Int('p', "nats-port", 0, "NATS server port. If not specified, NATS will not listen on any port.")
@@ -320,10 +320,13 @@ func buildRootCommand(ctx context.Context) *ff.Command {
 		}
 
 		bpath := *basePath
+		if *tlsDomain != "" {
+			bpath = "https://" + *tlsDomain + "/"
+		}
 		if bpath == "" {
 			bpath = "/"
 		}
-		if bpath[0] != '/' {
+		if !strings.HasPrefix(bpath, "http://") && !strings.HasPrefix(bpath, "https://") && bpath[0] != '/' {
 			bpath = "/" + bpath
 		}
 		if bpath[len(bpath)-1] != '/' {

--- a/server/web/handler/dashboard.go
+++ b/server/web/handler/dashboard.go
@@ -530,7 +530,7 @@ func RequestDashboardDownload(app *core.App, internalUrl string, pdfDateFormat s
 		//       We already know the basepath, but we don't know the scheme, host and port for certain because of possible reverse proxy setups.
 		//       We can try to reconstruct the url depending on if TLS is configured and by looking at the request headers.
 		//       But we need a fallback so the user can configure the base URL. Probably as a flag in main.go
-		u := fmt.Sprintf("/api/download/%s/%s", token, filename)
+		u := getDownloadURL(app.BasePath, token, filename)
 
 		return c.JSON(http.StatusOK, struct {
 			URL string `json:"url"`
@@ -677,7 +677,7 @@ func DownloadSQL(app *core.App, internalUrl string, pdfDateFormat string) echo.H
 			}{Error: err.Error()}, "  ")
 		}
 
-		u := fmt.Sprintf("/api/download/%s/%s", token, filename)
+		u := getDownloadURL(app.BasePath, token, filename)
 
 		return c.JSON(http.StatusOK, struct {
 			URL string `json:"url"`
@@ -863,4 +863,9 @@ func generateDownloadToken() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(bytes), nil
+}
+
+func getDownloadURL(basePath, token, filename string) string {
+	prefix := strings.TrimSuffix(basePath, "/")
+	return fmt.Sprintf("%s/api/download/%s/%s", prefix, token, filename)
 }

--- a/server/web/web.go
+++ b/server/web/web.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"shaper/server/core"
 	"strings"
 	"time"
@@ -119,14 +120,22 @@ func Start(
 		app.Logger.Info("Open https://" + tlsDomain + " in your browser")
 	} else {
 		app.Logger.Info("Web server is listening at " + addr + "")
-		if app.BasePath == "/" {
-			logPrefix := ""
-			if !strings.HasPrefix(addr, ":") {
-				logPrefix = "http://"
-			}
-			app.Logger.Info("Open " + logPrefix + addr + " in your browser")
+		if strings.HasPrefix(app.BasePath, "http://") || strings.HasPrefix(app.BasePath, "https://") {
+			app.Logger.Info("Open " + app.BasePath + " in your browser")
 		} else {
-			app.Logger.Info("Custom base path set. Opening the app in your browser directly won't work as expected. You are likely using a reverse proxy and need to access the app through it.", slog.Any("basepath", app.BasePath))
+			u, err := url.Parse(app.BasePath)
+			if err != nil {
+				e.Logger.Fatal("Error parsing base path", slog.Any("basepath", app.BasePath), slog.Any("error", err))
+			}
+			if u.Path == "/" {
+				logPrefix := ""
+				if !strings.HasPrefix(addr, ":") {
+					logPrefix = "http://"
+				}
+				app.Logger.Info("Open " + logPrefix + addr + " in your browser")
+			} else {
+				app.Logger.Info("Custom base path set. Opening the app in your browser directly won't work as expected. You are likely using a reverse proxy and need to access the app through it.", slog.Any("basepath", app.BasePath))
+			}
 		}
 	}
 

--- a/ui/src/components/dashboard/DashboardButton.tsx
+++ b/ui/src/components/dashboard/DashboardButton.tsx
@@ -68,7 +68,9 @@ function DashboardButton ({
       if (!response.ok) {
         throw new Error("Download request failed: " + (json.error || response.statusText));
       }
-      const downloadUrl = `${baseUrl?.endsWith("/") ? baseUrl.substring(0, baseUrl.length - 1) : baseUrl}${json.url}`;
+      const downloadUrl = (json.url as string).startsWith("http://") || (json.url as string).startsWith("https://")
+        ? json.url
+        : `${baseUrl?.endsWith("/") ? baseUrl.substring(0, baseUrl.length - 1) : baseUrl}${json.url}`;
       const filename = downloadUrl.split("/").pop() || "download";
 
       const link = document.createElement("a");

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -26,7 +26,9 @@ if (!supportsContainerQueries) {
 // Create a new router instance
 const router = createRouter({
   routeTree,
-  basepath: window.shaper.defaultBaseUrl || "/",
+  basepath: window.shaper.defaultBaseUrl.startsWith("http://") || window.shaper.defaultBaseUrl.startsWith("https://")
+    ? new URL(window.shaper.defaultBaseUrl).pathname
+    : window.shaper.defaultBaseUrl || "/",
   defaultPreload: false,
   defaultErrorComponent: ({ error }) => <ErrorComponent error={error} />,
   defaultStaleTime: 5000,


### PR DESCRIPTION
Making use of basepath config for this.

Works out of the box if you are using tls-domain since then the URL is obvious.
Otherwise have to set basepath to a full url to get full download links