### PR TITLE
Special support for in-memory database

### DIFF
--- a/main.go
+++ b/main.go
@@ -588,7 +588,13 @@ func Run(cfg Config) func(context.Context) {
 		}
 		logger.Info("Set DuckDB extension directory", slog.Any("path", cfg.DuckDBExtDir))
 	}
-	if cfg.DuckDBSecretDir != "" {
+	if cfg.DuckDB == ":memory:" {
+		_, err := duckdbSqlxDb.Exec("SET allow_persistent_secrets = false")
+		if err != nil {
+			logger.Error("Failed to disable persistent secrets", slog.Any("error", err))
+			os.Exit(1)
+		}
+	} else if cfg.DuckDBSecretDir != "" {
 		_, err := duckdbSqlxDb.Exec("SET secret_directory = ?", cfg.DuckDBSecretDir)
 		if err != nil {
 			logger.Error("Failed to set DuckDB secret directory", slog.String("path", cfg.DuckDBSecretDir), slog.Any("error", err))

--- a/main.go
+++ b/main.go
@@ -597,17 +597,18 @@ func Run(cfg Config) func(context.Context) {
 		logger.Info("Set DuckDB secret directory", slog.Any("path", cfg.DuckDBSecretDir))
 	}
 
+	initSQL := ""
 	if cfg.InitSQL != "" {
-		logger.Info("Executing init-sql")
-		// Substitute environment variables in the SQL
 		sql := os.ExpandEnv(strings.TrimSpace(util.StripSQLComments(cfg.InitSQL)))
-		if sql == "" {
-			logger.Info("init-sql specified but empty, skipping")
-		} else {
-			_, err := duckdbSqlxDb.Exec(sql)
-			if err != nil {
-				logger.Error("Failed to execute init-sql", slog.String("sql", sql), slog.Any("error", err))
-				os.Exit(1)
+		if sql != "" {
+			initSQL += sql + ";\n"
+			if cfg.DuckDB != ":memory:" {
+				logger.Info("Executing init-sql")
+				_, err := duckdbSqlxDb.Exec(sql)
+				if err != nil {
+					logger.Error("Failed to execute init-sql", slog.String("sql", sql), slog.Any("error", err))
+					os.Exit(1)
+				}
 			}
 		}
 	}
@@ -626,11 +627,14 @@ func Run(cfg Config) func(context.Context) {
 			if len(sql) == 0 {
 				logger.Info("init-sql-file is empty, skipping", slog.Any("path", cfg.InitSQLFile))
 			} else {
-				logger.Info("Executing init-sql-file")
-				_, err = duckdbSqlxDb.Exec(sql)
-				if err != nil {
-					logger.Error("Failed to execute init-sql-file", slog.String("path", cfg.InitSQLFile), slog.Any("error", err))
-					os.Exit(1)
+				initSQL += sql + ";\n"
+				if cfg.DuckDB != ":memory:" {
+					logger.Info("Executing init-sql-file")
+					_, err = duckdbSqlxDb.Exec(sql)
+					if err != nil {
+						logger.Error("Failed to execute init-sql-file", slog.String("path", cfg.InitSQLFile), slog.Any("error", err))
+						os.Exit(1)
+					}
 				}
 			}
 		}
@@ -645,6 +649,10 @@ func Run(cfg Config) func(context.Context) {
 		Version,
 		sqliteDbx,
 		duckdbSqlxDb,
+		duckDBFile,
+		cfg.DuckDBExtDir,
+		cfg.DuckDBSecretDir,
+		initSQL,
 		cfg.DeprecatedSchema,
 		logger,
 		cfg.BasePath,

--- a/server/core/app.go
+++ b/server/core/app.go
@@ -203,18 +203,17 @@ func (app *App) GetDuckDB(ctx context.Context) (*sqlx.DB, func(), error) {
 		}
 	}
 
+	// Always disable persistent secrets for in-memory mode to ensure isolation from central secret store
+	if _, err := dbx.Exec("SET allow_persistent_secrets = false"); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to disable persistent secrets: %w", err)
+	}
+
 	if app.DuckDBExtDir != "" {
 		_, err := dbx.Exec("SET extension_directory = ?", app.DuckDBExtDir)
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("failed to set DuckDB extension directory: %w", err)
-		}
-	}
-	if app.DuckDBSecretDir != "" {
-		_, err := dbx.Exec("SET secret_directory = ?", app.DuckDBSecretDir)
-		if err != nil {
-			cleanup()
-			return nil, nil, fmt.Errorf("failed to set DuckDB secret directory: %w", err)
 		}
 	}
 

--- a/server/core/app.go
+++ b/server/core/app.go
@@ -4,10 +4,12 @@ package core
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"time"
 
+	"github.com/duckdb/duckdb-go/v2"
 	"github.com/jmoiron/sqlx"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -24,6 +26,10 @@ type App struct {
 	Version                    string
 	Sqlite                     *sqlx.DB
 	DuckDB                     *sqlx.DB
+	DuckDBDSN                  string
+	DuckDBExtDir               string
+	DuckDBSecretDir            string
+	InitSQL                    string
 	Logger                     *slog.Logger
 	LoginRequired              bool
 	BasePath                   string
@@ -70,6 +76,10 @@ func New(
 	version string,
 	sqliteDbx *sqlx.DB,
 	duckDbx *sqlx.DB,
+	duckDBDSN string,
+	duckDBExtDir string,
+	duckDBSecretDir string,
+	initSQL string,
 	deprecatedSchema string,
 	logger *slog.Logger,
 	baseURL string,
@@ -101,13 +111,15 @@ func New(
 		return nil, err
 	}
 
-	if err := initDuckDB(duckDbx); err != nil {
-		return nil, err
-	}
+	if duckDBDSN != ":memory:" {
+		if err := initDuckDB(duckDbx); err != nil {
+			return nil, err
+		}
 
-	// TODO: Remove this once data is migrated for all active users
-	if err := migrateSystemData(sqliteDbx, duckDbx, deprecatedSchema, logger); err != nil {
-		return nil, err
+		// TODO: Remove this once data is migrated for all active users
+		if err := migrateSystemData(sqliteDbx, duckDbx, deprecatedSchema, logger); err != nil {
+			return nil, err
+		}
 	}
 
 	loginRequired, err := isLoginRequired(sqliteDbx)
@@ -137,6 +149,10 @@ func New(
 		Version:                    version,
 		Sqlite:                     sqliteDbx,
 		DuckDB:                     duckDbx,
+		DuckDBDSN:                  duckDBDSN,
+		DuckDBExtDir:               duckDBExtDir,
+		DuckDBSecretDir:            duckDBSecretDir,
+		InitSQL:                    initSQL,
 		Logger:                     logger,
 		LoginRequired:              loginRequired,
 		BasePath:                   baseURL,
@@ -166,6 +182,56 @@ func New(
 		TaskTimers:                 make(map[string]*time.Timer),
 	}
 	return app, nil
+}
+
+func (app *App) GetDuckDB(ctx context.Context) (*sqlx.DB, func(), error) {
+	if app.DuckDBDSN != ":memory:" {
+		return app.DuckDB, func() {}, nil
+	}
+
+	connector, err := duckdb.NewConnector(app.DuckDBDSN, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create DuckDB connector: %w", err)
+	}
+	db := sql.OpenDB(connector)
+	db.SetMaxIdleConns(0)
+	dbx := sqlx.NewDb(db, "duckdb")
+
+	cleanup := func() {
+		if err := dbx.Close(); err != nil {
+			app.Logger.Error("failed to close in-memory DuckDB", slog.Any("error", err))
+		}
+	}
+
+	if app.DuckDBExtDir != "" {
+		_, err := dbx.Exec("SET extension_directory = ?", app.DuckDBExtDir)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("failed to set DuckDB extension directory: %w", err)
+		}
+	}
+	if app.DuckDBSecretDir != "" {
+		_, err := dbx.Exec("SET secret_directory = ?", app.DuckDBSecretDir)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("failed to set DuckDB secret directory: %w", err)
+		}
+	}
+
+	if err := initDuckDB(dbx); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to initialize DuckDB: %w", err)
+	}
+
+	if app.InitSQL != "" {
+		_, err := dbx.Exec(app.InitSQL)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("failed to execute init-sql: %w", err)
+		}
+	}
+
+	return dbx, cleanup, nil
 }
 
 func (app *App) Init(nc *nats.Conn) error {

--- a/server/core/get_dashboard.go
+++ b/server/core/get_dashboard.go
@@ -25,7 +25,6 @@ const QUERY_MAX_ROWS = 3000
 // They are not visible in the dashboard output.
 var sideEffectSQLStatements = [][]string{
 	{"SET", "VARIABLE"},
-	{"SET"},
 	{"BEGIN"},
 	{"COMMIT"},
 	{"ROLLBACK"},

--- a/server/core/get_dashboard.go
+++ b/server/core/get_dashboard.go
@@ -104,7 +104,13 @@ func QueryDashboard(app *App, ctx context.Context, dashboardQuery DashboardQuery
 	headerImage := ""
 	footerLink := ""
 
-	conn, err := app.DuckDB.Connx(ctx)
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return result, fmt.Errorf("Error getting DB: %v", err)
+	}
+	defer cleanup()
+
+	conn, err := db.Connx(ctx)
 	if err != nil {
 		return result, fmt.Errorf("Error getting conn: %v", err)
 	}
@@ -114,14 +120,14 @@ func QueryDashboard(app *App, ctx context.Context, dashboardQuery DashboardQuery
 		if sqlString == "" {
 			continue
 		}
-		if !IsAllowedStatement(sqlString) {
+		if !IsAllowedStatement(app, sqlString) {
 			return result, fmt.Errorf("Disallowed SQL statement in query %d", queryIndex+1)
 		}
 		if nextIsDownload {
 			nextIsDownload = false
 			continue
 		}
-		if hideNextContentSection && !isSideEffect(sqlString) && !canStartSection(sqlString) {
+		if hideNextContentSection && !isSideEffect(app, sqlString) && !canStartSection(sqlString) {
 			continue
 		}
 		varPrefix, varCleanup := buildVarPrefix(singleVars, multiVars)
@@ -160,7 +166,7 @@ func QueryDashboard(app *App, ctx context.Context, dashboardQuery DashboardQuery
 			}
 		}
 
-		if isSideEffect(sqlString) {
+		if isSideEffect(app, sqlString) {
 			continue
 		}
 
@@ -658,8 +664,11 @@ func findBoxlotColumnIndex(columns []*sql.ColumnType) int {
 
 // Some SQL statements are only used for their side effects and should not be shown on the dashboard.
 // We ignore case and extra whitespace when matching the statements
-func isSideEffect(sqlString string) bool {
+func isSideEffect(app *App, sqlString string) bool {
 	upper := strings.ToUpper(strings.TrimSpace(sqlString))
+	if app != nil && app.DuckDBDSN == ":memory:" && strings.HasPrefix(upper, "ATTACH") {
+		return true
+	}
 	for _, stmt := range sideEffectSQLStatements {
 		if matchesPrefix(upper, stmt) {
 			return true
@@ -684,7 +693,7 @@ func matchesPrefix(upperSql string, prefix []string) bool {
 	return true
 }
 
-func IsAllowedStatement(sql string) bool {
+func IsAllowedStatement(app *App, sql string) bool {
 	sql = strings.TrimSpace(sql)
 	if sql == "" {
 		return true
@@ -698,11 +707,11 @@ func IsAllowedStatement(sql string) bool {
 			return false
 		}
 		for _, cte := range ctes {
-			if !IsAllowedStatement(cte) {
+			if !IsAllowedStatement(app, cte) {
 				return false
 			}
 		}
-		return IsAllowedStatement(remaining)
+		return IsAllowedStatement(app, remaining)
 	}
 
 	// Handle parenthesized queries like (SELECT 1)
@@ -711,7 +720,7 @@ func IsAllowedStatement(sql string) bool {
 		if err != nil {
 			return false
 		}
-		if !IsAllowedStatement(inner) {
+		if !IsAllowedStatement(app, inner) {
 			return false
 		}
 		remaining = strings.TrimSpace(remaining)
@@ -730,7 +739,7 @@ func IsAllowedStatement(sql string) bool {
 				} else if strings.HasPrefix(restUpper, "DISTINCT") {
 					rest = strings.TrimSpace(rest[len("DISTINCT"):])
 				}
-				return IsAllowedStatement(rest)
+				return IsAllowedStatement(app, rest)
 			}
 		}
 		// Also handle ORDER BY, LIMIT etc which can follow a parenthesized query
@@ -741,7 +750,7 @@ func IsAllowedStatement(sql string) bool {
 	}
 
 	// Check against side effects
-	if isSideEffect(sql) {
+	if isSideEffect(app, sql) {
 		return true
 	}
 
@@ -761,7 +770,7 @@ func IsAllowedStatement(sql string) bool {
 				if rest == "" {
 					return true
 				}
-				return IsAllowedStatement(rest)
+				return IsAllowedStatement(app, rest)
 			}
 			return true
 		}

--- a/server/core/run_task.go
+++ b/server/core/run_task.go
@@ -57,7 +57,12 @@ func RunTask(app *App, ctx context.Context, content string) (TaskResult, error) 
 	}
 	result.TotalQueries = len(sqls)
 
-	conn, err := app.DuckDB.Connx(ctx)
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return result, fmt.Errorf("Error getting DB: %v", err)
+	}
+	defer cleanup()
+	conn, err := db.Connx(ctx)
 	if err != nil {
 		return result, fmt.Errorf("Error getting conn: %v", err)
 	}

--- a/server/core/schedule_task.go
+++ b/server/core/schedule_task.go
@@ -39,7 +39,12 @@ func getNextTaskRun(app *App, ctx context.Context, content string) (*time.Time, 
 	if len(sqls) == 0 {
 		return nil, "", fmt.Errorf("no SQL queries found in task content")
 	}
-	conn, err := app.DuckDB.Connx(ctx)
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("Error getting DB: %v", err)
+	}
+	defer cleanup()
+	conn, err := db.Connx(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get database connection: %w", err)
 	}

--- a/server/core/sql_validation_test.go
+++ b/server/core/sql_validation_test.go
@@ -77,9 +77,18 @@ func TestIsAllowedStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, IsAllowedStatement(tt.sql), "SQL: %s", tt.sql)
+			assert.Equal(t, tt.expected, IsAllowedStatement(nil, tt.sql), "SQL: %s", tt.sql)
 		})
 	}
+}
+
+func TestIsAllowedStatementMemory(t *testing.T) {
+	appMemory := &App{DuckDBDSN: ":memory:"}
+	appFile := &App{DuckDBDSN: "file.db"}
+
+	assert.True(t, IsAllowedStatement(appMemory, "ATTACH 'data.db' AS data"))
+	assert.False(t, IsAllowedStatement(appFile, "ATTACH 'data.db' AS data"))
+	assert.False(t, IsAllowedStatement(nil, "ATTACH 'data.db' AS data"))
 }
 
 func TestSplitWithStatement(t *testing.T) {

--- a/server/core/stream_query.go
+++ b/server/core/stream_query.go
@@ -28,7 +28,7 @@ const EXCEL_INTERVAL_FORMAT = "[h]:mm:ss"
 
 var excludedTypesRegex = regexp.MustCompile(`\b(LABEL|SECTION|XLINE|YLINE|DROPDOWN|DOWNLOAD_CSV|DOWNLOAD_XLSX|DOWNLOAD_JSON|DOWNLOAD_PDF|DATEPICKER|DATEPICKER_FROM|DATEPICKER_TO|PLACEHOLDER|INPUT|RELOAD|HEADER_IMAGE|FOOTER_LINK)\b`)
 
-func resolveDownloadQueryID(sqls []string, downloadType string) (int, error) {
+func resolveDownloadQueryID(app *App, sqls []string, downloadType string) (int, error) {
 	upperType := "DOWNLOAD_" + strings.ToUpper(downloadType)
 	foundIndex := -1
 	count := 0
@@ -45,7 +45,7 @@ func resolveDownloadQueryID(sqls []string, downloadType string) (int, error) {
 	foundIndex = -1
 	count = 0
 	for i, s := range sqls {
-		if isSideEffect(s) {
+		if isSideEffect(app, s) {
 			continue
 		}
 		upper := strings.ToUpper(s)
@@ -86,7 +86,7 @@ func StreamQueryCSV(
 	}
 
 	if queryID == -1 {
-		queryID, err = resolveDownloadQueryID(sqls, "csv")
+		queryID, err = resolveDownloadQueryID(app, sqls, "csv")
 		if err != nil {
 			return err
 		}
@@ -96,18 +96,23 @@ func StreamQueryCSV(
 		return fmt.Errorf("dashboard '%s' has no query for query index: %d", dashboardId, queryID)
 	}
 	query := sqls[queryID]
-	if !IsAllowedStatement(query) {
+	if !IsAllowedStatement(app, query) {
 		return fmt.Errorf("disallowed SQL statement in query %d", queryID+1)
 	}
 
-	conn, err := app.DuckDB.Connx(ctx)
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return fmt.Errorf("Error getting DB: %v", err)
+	}
+	defer cleanup()
+	conn, err := db.Connx(ctx)
 	if err != nil {
 		return fmt.Errorf("Error getting conn: %v", err)
 	}
 	defer conn.Close()
 
 	// Execute the query and get rows
-	varPrefix, varCleanup, err := getVarPrefix(conn, ctx, sqls, params, variables)
+	varPrefix, varCleanup, err := getVarPrefix(app, conn, ctx, sqls, params, variables)
 	if err != nil {
 		return fmt.Errorf("failed to get variable prefix: %w", err)
 	}
@@ -129,10 +134,15 @@ func StreamSQLToCSV(
 	sqlQuery string,
 	writer io.Writer,
 ) error {
-	if !IsAllowedStatement(sqlQuery) {
+	if !IsAllowedStatement(app, sqlQuery) {
 		return fmt.Errorf("disallowed SQL statement")
 	}
-	conn, err := app.DuckDB.Connx(ctx)
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return fmt.Errorf("Error getting DB: %v", err)
+	}
+	defer cleanup()
+	conn, err := db.Connx(ctx)
 	if err != nil {
 		return fmt.Errorf("Error getting conn: %v", err)
 	}
@@ -163,7 +173,7 @@ func StreamQueryJSON(
 	}
 
 	if queryID == -1 {
-		queryID, err = resolveDownloadQueryID(sqls, "json")
+		queryID, err = resolveDownloadQueryID(app, sqls, "json")
 		if err != nil {
 			return err
 		}
@@ -173,18 +183,23 @@ func StreamQueryJSON(
 		return fmt.Errorf("dashboard '%s' has no query for query index: %d", dashboardId, queryID)
 	}
 	query := sqls[queryID]
-	if !IsAllowedStatement(query) {
+	if !IsAllowedStatement(app, query) {
 		return fmt.Errorf("disallowed SQL statement in query %d", queryID+1)
 	}
 
-	conn, err := app.DuckDB.Connx(ctx)
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return fmt.Errorf("Error getting DB: %v", err)
+	}
+	defer cleanup()
+	conn, err := db.Connx(ctx)
 	if err != nil {
 		return fmt.Errorf("Error getting conn: %v", err)
 	}
 	defer conn.Close()
 
 	// Execute the query and get rows
-	varPrefix, varCleanup, err := getVarPrefix(conn, ctx, sqls, params, variables)
+	varPrefix, varCleanup, err := getVarPrefix(app, conn, ctx, sqls, params, variables)
 	if err != nil {
 		return fmt.Errorf("failed to get variable prefix: %w", err)
 	}
@@ -206,10 +221,15 @@ func StreamSQLToJSON(
 	sqlQuery string,
 	writer io.Writer,
 ) error {
-	if !IsAllowedStatement(sqlQuery) {
+	if !IsAllowedStatement(app, sqlQuery) {
 		return fmt.Errorf("disallowed SQL statement")
 	}
-	conn, err := app.DuckDB.Connx(ctx)
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return fmt.Errorf("Error getting DB: %v", err)
+	}
+	defer cleanup()
+	conn, err := db.Connx(ctx)
 	if err != nil {
 		return fmt.Errorf("Error getting conn: %v", err)
 	}
@@ -400,7 +420,7 @@ func StreamQueryXLSX(
 	}
 
 	if queryID == -1 {
-		queryID, err = resolveDownloadQueryID(sqls, "xlsx")
+		queryID, err = resolveDownloadQueryID(app, sqls, "xlsx")
 		if err != nil {
 			return err
 		}
@@ -410,7 +430,7 @@ func StreamQueryXLSX(
 		return fmt.Errorf("dashboard '%s' has no query for query index: %d", dashboardId, queryID)
 	}
 	query := sqls[queryID]
-	if !IsAllowedStatement(query) {
+	if !IsAllowedStatement(app, query) {
 		return fmt.Errorf("disallowed SQL statement in query %d", queryID+1)
 	}
 
@@ -459,13 +479,18 @@ func StreamQueryXLSX(
 		}),
 	}
 
-	conn, err := app.DuckDB.Connx(ctx)
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return fmt.Errorf("Error getting DB: %v", err)
+	}
+	defer cleanup()
+	conn, err := db.Connx(ctx)
 	if err != nil {
 		return fmt.Errorf("Error getting conn: %v", err)
 	}
 
 	// Execute the query and get rows
-	varPrefix, varCleanup, err := getVarPrefix(conn, ctx, sqls, params, variables)
+	varPrefix, varCleanup, err := getVarPrefix(app, conn, ctx, sqls, params, variables)
 	if err != nil {
 		return fmt.Errorf("failed to get variable prefix: %w", err)
 	}
@@ -704,7 +729,7 @@ func createStyle(xlsx *excelize.File, style *excelize.Style) int {
 	return styleID
 }
 
-func getVarPrefix(conn *sqlx.Conn, ctx context.Context, sqlQueries []string, queryParams url.Values, variables map[string]any) (string, string, error) {
+func getVarPrefix(app *App, conn *sqlx.Conn, ctx context.Context, sqlQueries []string, queryParams url.Values, variables map[string]any) (string, string, error) {
 	nextIsDownload := false
 	// TODO: currently variables have to be defined in the order they are used. create a dependency graph for queryies instead
 	singleVars, multiVars, err := getTokenVars(variables)
@@ -717,7 +742,7 @@ func getVarPrefix(conn *sqlx.Conn, ctx context.Context, sqlQueries []string, que
 		if sqlString == "" {
 			continue
 		}
-		if !IsAllowedStatement(sqlString) {
+		if !IsAllowedStatement(app, sqlString) {
 			return "", "", fmt.Errorf("disallowed SQL statement in query %d", queryIndex+1)
 		}
 		if nextIsDownload {

--- a/server/core/stream_query_test.go
+++ b/server/core/stream_query_test.go
@@ -137,7 +137,7 @@ func TestResolveDownloadQueryID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveDownloadQueryID(tt.sqls, tt.downloadType)
+			got, err := resolveDownloadQueryID(nil, tt.sqls, tt.downloadType)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("resolveDownloadQueryID() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/server/web/handler/sql.go
+++ b/server/web/handler/sql.go
@@ -48,7 +48,7 @@ func ExecuteSQL(app *core.App) echo.HandlerFunc {
 				}{Error: "Only one SQL query is allowed"}, "  ")
 		}
 
-		if !core.IsAllowedStatement(queries[0]) {
+		if !core.IsAllowedStatement(app, queries[0]) {
 			return c.JSONPretty(http.StatusBadRequest,
 				struct {
 					Error string `json:"error"`


### PR DESCRIPTION
Use `--duckdb :memory:` to enable.

Shaper then uses a new database for every request. 

Plus we allow `ATTACH` in dashboards in this mode.