### PR TITLE
Use gosu in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@
 # Using Debian over Alpine since Debian uses glibc and DuckDB has issues with musl.
 FROM debian:13.4-slim
 
-# install wget for healthchecks and dependencies for headless-shell
+# install wget for healthchecks and dependencies for headless-shell and gosu for stepping down from root
 RUN apt-get update -y \
-  && apt-get install --no-install-recommends -y wget ca-certificates libnspr4 libnss3 libexpat1 libfontconfig1 libuuid1 socat \
+  && apt-get install --no-install-recommends -y wget ca-certificates libnspr4 libnss3 libexpat1 libfontconfig1 libuuid1 socat gosu \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -53,7 +53,9 @@ RUN groupadd -r shaper && useradd -r -g shaper shaper \
 # Copy the correct binary based on architecture
 COPY bin/shaper-linux-${TARGETARCH} /usr/local/bin/shaper
 
-# Run as non-root user to restrict file access
-USER shaper
+# Copy and setup entrypoint
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-ENTRYPOINT ["/usr/local/bin/shaper"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["/usr/local/bin/shaper"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# If the first argument looks like a flag (starts with -), prepend the binary
+# Also prepend the binary if it's a known subcommand
+if [ "${1#-}" != "$1" ] || [ "$1" = 'dev' ] || [ "$1" = 'pull' ] || [ "$1" = 'deploy' ]; then
+	set -- /usr/local/bin/shaper "$@"
+fi
+
+# If we are running the shaper binary and we are root,
+# fix permissions on data directories and step down to shaper user
+if [ "$1" = '/usr/local/bin/shaper' ] && [ "$(id -u)" = '0' ]; then
+    # Ensure directories exist (in case they are not mounted)
+    mkdir -p /data /var/lib/shaper
+
+    # Fix permissions on data directories if they are owned by root.
+    # We use a conditional check to avoid slow chown on every startup if already correct.
+    # But since /data might have many files, we'll just do it if the root of the volume is root-owned.
+    if [ "$(stat -c %u /data)" = '0' ]; then
+        chown -R shaper:shaper /data
+    fi
+    if [ "$(stat -c %u /var/lib/shaper)" = '0' ]; then
+        chown -R shaper:shaper /var/lib/shaper
+    fi
+
+    exec gosu shaper "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
We want to run as non-root user.
But if we do that directly we will have permission errors reading existing volumes and data within them.
So instead we are now using a entrypoint script and the run shaper via gosu.
The official postgres image and other images with state do the same.