### PR TITLE
Adds `shaper ids` command

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,6 +254,7 @@ func buildRootCommand(ctx context.Context) *ff.Command {
 	subcommands = append(subcommands,
 		addDevSubcommand(rootCmd),
 		addPullSubcommand(rootCmd),
+		addIdsSubcommand(rootCmd),
 		addDeploySubcommand(rootCmd),
 	)
 
@@ -461,6 +462,29 @@ func addPullSubcommand(rootCmd *ff.Command) *ff.Command {
 	}
 	rootCmd.Subcommands = append(rootCmd.Subcommands, pullCmd)
 	return pullCmd
+}
+
+func addIdsSubcommand(rootCmd *ff.Command) *ff.Command {
+	idsFlags := ff.NewFlagSet("ids")
+	help := idsFlags.Bool('h', "help", "show help")
+	idsConfigPath := idsFlags.StringLong("config", "./shaper.json", "Path to config file")
+
+	usage := "add missing IDs to all dashboards in the configured directory"
+	idsCmd := &ff.Command{
+		Name:      "ids",
+		Usage:     "shaper ids [--config path]",
+		ShortHelp: usage,
+		Flags:     idsFlags,
+		Exec: func(ctx context.Context, args []string) error {
+			if *help {
+				fmt.Printf("%s\n", ffhelp.Flags(idsFlags, usage))
+				return nil
+			}
+			return dev.RunIdsCommand(ctx, *idsConfigPath)
+		},
+	}
+	rootCmd.Subcommands = append(rootCmd.Subcommands, idsCmd)
+	return idsCmd
 }
 
 func addDeploySubcommand(rootCmd *ff.Command) *ff.Command {

--- a/server/dev/ids.go
+++ b/server/dev/ids.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package dev
+
+import (
+	"context"
+	"fmt"
+)
+
+func RunIdsCommand(ctx context.Context, configPath string) error {
+	cfg, err := loadOrPromptConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	watchDir, err := resolveAbsolutePath(cfg.Directory)
+	if err != nil {
+		return fmt.Errorf("failed to resolve directory: %w", err)
+	}
+	if err := ensureDirExists(watchDir); err != nil {
+		return err
+	}
+
+	fmt.Printf("Adding missing IDs to dashboards in %s...\n", watchDir)
+
+	fileCount, err := ensureShaperIDsForDir(watchDir)
+	if err != nil {
+		return err
+	}
+
+	pluralSuffix := ""
+	if fileCount != 1 {
+		pluralSuffix = "s"
+	}
+	fmt.Printf("\nDone. Processed %d dashboard%s.\n", fileCount, pluralSuffix)
+
+	return nil
+}


### PR DESCRIPTION
Same as `dev` command this adds ids to all dashboard sql file files that don't have ids yet.