### PR TITLE
Add getenv() function to init-sql

### DIFF
--- a/main.go
+++ b/main.go
@@ -632,9 +632,13 @@ func Run(cfg Config) func(context.Context) {
 
 	initSQL := ""
 	if cfg.InitSQL != "" {
-		sql := os.ExpandEnv(strings.TrimSpace(util.StripSQLComments(cfg.InitSQL)))
-		if sql != "" {
-			initSQL += sql + ";\n"
+		trimmed := strings.TrimSpace(util.StripSQLComments(cfg.InitSQL))
+		expanded := os.ExpandEnv(trimmed)
+		if expanded != trimmed {
+			logger.Warn("Using environment variables in init-sql via $VAR or ${VAR} is deprecated. Use the getenv() SQL function instead.")
+		}
+		if expanded != "" {
+			initSQL += expanded + ";\n"
 		}
 	}
 	if cfg.InitSQLFile != "" {
@@ -648,11 +652,15 @@ func Run(cfg Config) func(context.Context) {
 				os.Exit(1)
 			}
 		} else {
-			sql := os.ExpandEnv(strings.TrimSpace(util.StripSQLComments(string(data))))
-			if len(sql) == 0 {
+			trimmed := strings.TrimSpace(util.StripSQLComments(string(data)))
+			expanded := os.ExpandEnv(trimmed)
+			if expanded != trimmed {
+				logger.Warn("Using environment variables in init-sql-file via $VAR or ${VAR} is deprecated. Use the getenv() SQL function instead.")
+			}
+			if len(expanded) == 0 {
 				logger.Info("init-sql-file is empty, skipping", slog.Any("path", cfg.InitSQLFile))
 			} else {
-				initSQL += sql + ";\n"
+				initSQL += expanded + ";\n"
 			}
 		}
 	}

--- a/server/core/app.go
+++ b/server/core/app.go
@@ -132,7 +132,18 @@ func New(
 		if initSQL != "" {
 			logger.Info("Executing init-sql")
 			varPrefix, _ := buildVarPrefixWithDBName(internalDBName, nil, nil)
-			if _, err := duckDbx.Exec(varPrefix + initSQL); err != nil {
+
+			conn, err := duckDbx.Conn(context.Background())
+			if err != nil {
+				return nil, fmt.Errorf("failed to get connection for init-sql: %w", err)
+			}
+			defer conn.Close()
+
+			if err := duckdb.RegisterScalarUDF(conn, "getenv", &util.GetEnvFunc{}); err != nil {
+				return nil, fmt.Errorf("failed to register getenv UDF: %w", err)
+			}
+
+			if _, err := conn.ExecContext(context.Background(), varPrefix+initSQL); err != nil {
 				return nil, fmt.Errorf("failed to execute init-sql: %w", err)
 			}
 		}
@@ -247,8 +258,20 @@ func (app *App) GetDuckDB(ctx context.Context) (*sqlx.DB, func(), error) {
 
 	if app.InitSQL != "" {
 		varPrefix, _ := buildVarPrefix(app, nil, nil)
-		_, err := dbx.Exec(varPrefix + app.InitSQL)
+
+		conn, err := dbx.Conn(ctx)
 		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("failed to get connection for init-sql: %w", err)
+		}
+		defer conn.Close()
+
+		if err := duckdb.RegisterScalarUDF(conn, "getenv", &util.GetEnvFunc{}); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("failed to register getenv UDF: %w", err)
+		}
+
+		if _, err := conn.ExecContext(ctx, varPrefix+app.InitSQL); err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("failed to execute init-sql: %w", err)
 		}

--- a/server/core/app.go
+++ b/server/core/app.go
@@ -139,9 +139,12 @@ func New(
 			}
 			defer conn.Close()
 
-			if err := duckdb.RegisterScalarUDF(conn, "getenv", &util.GetEnvFunc{}); err != nil {
+			getenv := &util.GetEnvFunc{}
+			getenv.Enable()
+			if err := duckdb.RegisterScalarUDF(conn, "getenv", getenv); err != nil {
 				return nil, fmt.Errorf("failed to register getenv UDF: %w", err)
 			}
+			defer getenv.Disable()
 
 			if _, err := conn.ExecContext(context.Background(), varPrefix+initSQL); err != nil {
 				return nil, fmt.Errorf("failed to execute init-sql: %w", err)
@@ -266,10 +269,13 @@ func (app *App) GetDuckDB(ctx context.Context) (*sqlx.DB, func(), error) {
 		}
 		defer conn.Close()
 
-		if err := duckdb.RegisterScalarUDF(conn, "getenv", &util.GetEnvFunc{}); err != nil {
+		getenv := &util.GetEnvFunc{}
+		getenv.Enable()
+		if err := duckdb.RegisterScalarUDF(conn, "getenv", getenv); err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("failed to register getenv UDF: %w", err)
 		}
+		defer getenv.Disable()
 
 		if _, err := conn.ExecContext(ctx, varPrefix+app.InitSQL); err != nil {
 			cleanup()

--- a/server/snapshots/restore.go
+++ b/server/snapshots/restore.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/duckdb/duckdb-go/v2"
 	"github.com/jmoiron/sqlx"
 	"github.com/minio/minio-go/v7"
 	"github.com/nrednav/cuid2"
@@ -160,12 +160,22 @@ func restoreDuckDBSnapshot(ctx context.Context, duckdbPath string, config Config
 
 	if config.InitSQL != "" {
 		// Substitute environment variables in the SQL
-		sql, err := prepSQL(config.InitSQL)
+		sql, err := prepSQL(config.InitSQL, config.Logger)
 		if err != nil {
 			return fmt.Errorf("failed to prepare init-sql: %w", err)
 		}
 		if sql != "" {
-			_, err := tempDB.Exec(sql)
+			conn, err := tempDB.Conn(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get connection for init-sql: %w", err)
+			}
+			defer conn.Close()
+
+			if err := duckdb.RegisterScalarUDF(conn, "getenv", &util.GetEnvFunc{}); err != nil {
+				return fmt.Errorf("failed to register getenv UDF: %w", err)
+			}
+
+			_, err = conn.ExecContext(ctx, sql)
 			if err != nil {
 				return fmt.Errorf("failed to execute init-sql: %w", err)
 			}
@@ -178,13 +188,23 @@ func restoreDuckDBSnapshot(ctx context.Context, duckdbPath string, config Config
 				return fmt.Errorf("failed to read init-sql-file: %w", err)
 			}
 		} else {
-			sql, err := prepSQL(string(data))
+			sql, err := prepSQL(string(data), config.Logger)
 			if err != nil {
 				return fmt.Errorf("failed to prepare init-sql-file: %w", err)
 			}
 			if len(sql) != 0 {
+				conn, err := tempDB.Conn(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get connection for init-sql-file: %w", err)
+				}
+				defer conn.Close()
+
+				if err := duckdb.RegisterScalarUDF(conn, "getenv", &util.GetEnvFunc{}); err != nil {
+					return fmt.Errorf("failed to register getenv UDF: %w", err)
+				}
+
 				// Substitute environment variables in the SQL file content
-				_, err = tempDB.Exec(sql)
+				_, err = conn.ExecContext(ctx, sql)
 				if err != nil {
 					return fmt.Errorf("failed to execute init-sql-file: %w", err)
 				}
@@ -288,7 +308,7 @@ func checkDuckdbSnapshotHasData(ctx context.Context, client *minio.Client, bucke
 	return false, nil
 }
 
-func prepSQL(sql string) (string, error) {
+func prepSQL(sql string, logger *slog.Logger) (string, error) {
 	sql = util.StripSQLComments(sql)
 	parts, err := util.SplitSQLQueries(sql)
 	if err != nil {
@@ -304,8 +324,10 @@ func prepSQL(sql string) (string, error) {
 			}
 		}
 	}
-	sql = filteredSql
-	sql = strings.TrimSpace(sql)
-	sql = os.ExpandEnv(sql)
-	return sql, nil
+	sql = strings.TrimSpace(filteredSql)
+	expanded := os.ExpandEnv(sql)
+	if expanded != sql && logger != nil {
+		logger.Warn("Using environment variables in init-sql via $VAR or ${VAR} is deprecated. Use the getenv() SQL function instead.")
+	}
+	return expanded, nil
 }

--- a/server/snapshots/restore.go
+++ b/server/snapshots/restore.go
@@ -171,11 +171,13 @@ func restoreDuckDBSnapshot(ctx context.Context, duckdbPath string, config Config
 			}
 			defer conn.Close()
 
-			if err := duckdb.RegisterScalarUDF(conn, "getenv", &util.GetEnvFunc{}); err != nil {
+			getenv := &util.GetEnvFunc{}
+			getenv.Enable()
+			if err := duckdb.RegisterScalarUDF(conn, "getenv", getenv); err != nil {
 				return fmt.Errorf("failed to register getenv UDF: %w", err)
 			}
-
 			_, err = conn.ExecContext(ctx, sql)
+			getenv.Disable()
 			if err != nil {
 				return fmt.Errorf("failed to execute init-sql: %w", err)
 			}
@@ -199,12 +201,13 @@ func restoreDuckDBSnapshot(ctx context.Context, duckdbPath string, config Config
 				}
 				defer conn.Close()
 
-				if err := duckdb.RegisterScalarUDF(conn, "getenv", &util.GetEnvFunc{}); err != nil {
+				getenv := &util.GetEnvFunc{}
+				getenv.Enable()
+				if err := duckdb.RegisterScalarUDF(conn, "getenv", getenv); err != nil {
 					return fmt.Errorf("failed to register getenv UDF: %w", err)
 				}
-
-				// Substitute environment variables in the SQL file content
 				_, err = conn.ExecContext(ctx, sql)
+				getenv.Disable()
 				if err != nil {
 					return fmt.Errorf("failed to execute init-sql-file: %w", err)
 				}

--- a/server/util/duckdb.go
+++ b/server/util/duckdb.go
@@ -4,12 +4,17 @@ package util
 
 import (
 	"database/sql/driver"
+	"fmt"
 	"os"
+	"sync"
 
 	"github.com/duckdb/duckdb-go/v2"
 )
 
-type GetEnvFunc struct{}
+type GetEnvFunc struct {
+	mu      sync.RWMutex
+	enabled bool
+}
 
 func (f *GetEnvFunc) Config() duckdb.ScalarFuncConfig {
 	varcharInfo, _ := duckdb.NewTypeInfo(duckdb.TYPE_VARCHAR)
@@ -22,6 +27,11 @@ func (f *GetEnvFunc) Config() duckdb.ScalarFuncConfig {
 func (f *GetEnvFunc) Executor() duckdb.ScalarFuncExecutor {
 	return duckdb.ScalarFuncExecutor{
 		RowExecutor: func(values []driver.Value) (any, error) {
+			f.mu.RLock()
+			defer f.mu.RUnlock()
+			if !f.enabled {
+				return nil, fmt.Errorf("getenv() is only available during initialization")
+			}
 			if len(values) == 0 || values[0] == nil {
 				return nil, nil
 			}
@@ -32,4 +42,16 @@ func (f *GetEnvFunc) Executor() duckdb.ScalarFuncExecutor {
 			return os.Getenv(key), nil
 		},
 	}
+}
+
+func (f *GetEnvFunc) Enable() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.enabled = true
+}
+
+func (f *GetEnvFunc) Disable() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.enabled = false
 }

--- a/server/util/duckdb.go
+++ b/server/util/duckdb.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package util
+
+import (
+	"database/sql/driver"
+	"os"
+
+	"github.com/duckdb/duckdb-go/v2"
+)
+
+type GetEnvFunc struct{}
+
+func (f *GetEnvFunc) Config() duckdb.ScalarFuncConfig {
+	varcharInfo, _ := duckdb.NewTypeInfo(duckdb.TYPE_VARCHAR)
+	return duckdb.ScalarFuncConfig{
+		InputTypeInfos: []duckdb.TypeInfo{varcharInfo},
+		ResultTypeInfo: varcharInfo,
+	}
+}
+
+func (f *GetEnvFunc) Executor() duckdb.ScalarFuncExecutor {
+	return duckdb.ScalarFuncExecutor{
+		RowExecutor: func(values []driver.Value) (any, error) {
+			if len(values) == 0 || values[0] == nil {
+				return nil, nil
+			}
+			key, ok := values[0].(string)
+			if !ok {
+				return nil, nil
+			}
+			return os.Getenv(key), nil
+		},
+	}
+}


### PR DESCRIPTION
Same function as duckdb cli supports.
Not available in dashboards and tasks.

Log deprecation warning for using ${ENV} or $ENV.

This makes code more reusable between shaper and cli scripts. 
It also ensures you cannot inject random code as env var.