### PR TITLE
Fix: When manually triggering an init task,

### DIFF
--- a/server/core/run_task.go
+++ b/server/core/run_task.go
@@ -208,6 +208,7 @@ func executeTaskOnDB(app *App, ctx context.Context, db *sqlx.DB, content string)
 				timeVal := getScheduleTime(queryResult.ResultRows)
 				if timeVal == -1 {
 					isInit = true
+					scheduleType = "all"
 				}
 				result.NextRunAt = timeVal
 				result.ScheduleType = scheduleType

--- a/server/core/schedule_task.go
+++ b/server/core/schedule_task.go
@@ -458,7 +458,7 @@ func ManualTaskRun(app *App, ctx context.Context, content string) (TaskResult, e
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("failed to get next task run: %w", err)
 	}
-	if scheduleType == "all" {
+	if scheduleType == "all" || scheduleType == "init" {
 		broadcastManualTask(app, content)
 	}
 	return RunTask(app, ctx, content)

--- a/server/core/task_init_test.go
+++ b/server/core/task_init_test.go
@@ -74,7 +74,7 @@ func TestInitTask(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, result.Success)
 		assert.Equal(t, int64(-1), result.NextRunAt)
-		assert.Equal(t, "single", result.ScheduleType)
+		assert.Equal(t, "all", result.ScheduleType)
 
 		// Verify table was created and data inserted (since no transaction for init)
 		var val int32


### PR DESCRIPTION
it should run on all nodes