### PR TITLE
Tasks as files

### DIFF
--- a/server/core/task.go
+++ b/server/core/task.go
@@ -88,7 +88,7 @@ func GetTask(app *App, ctx context.Context, id string) (Task, error) {
 	return task, nil
 }
 
-func CreateTask(app *App, ctx context.Context, name string, content string, path string) (string, error) {
+func CreateTask(app *App, ctx context.Context, name string, content string, path string, requestedID string) (string, error) {
 	actor := ActorFromContext(ctx)
 	if actor == nil {
 		return "", fmt.Errorf("no actor in context")
@@ -98,7 +98,12 @@ func CreateTask(app *App, ctx context.Context, name string, content string, path
 	if name == "" {
 		return "", fmt.Errorf("task name cannot be empty")
 	}
+
 	id := cuid2.Generate()
+	if requestedID != "" {
+		id = requestedID
+	}
+
 	err := app.SubmitState(ctx, "create_task", CreateTaskPayload{
 		ID:        id,
 		Timestamp: time.Now(),

--- a/server/dev/config.go
+++ b/server/dev/config.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 )
 
 const (
@@ -26,7 +25,6 @@ const (
 type Config struct {
 	URL       string     `json:"url"`
 	Directory string     `json:"directory"`
-	LastPull  *time.Time `json:"lastPull,omitempty"`
 }
 
 var ErrConfigNotFound = errors.New("config file not found")

--- a/server/dev/deploy.go
+++ b/server/dev/deploy.go
@@ -43,7 +43,7 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 		return err
 	}
 
-	watchDir, err := resolveAbsolutePath(cfg.Directory)
+	watchDir, err := resolveConfigDirectory(cfg.Directory, configPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve directory: %w", err)
 	}

--- a/server/dev/deploy.go
+++ b/server/dev/deploy.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -24,12 +23,13 @@ const (
 )
 
 type LocalApp struct {
-	ID       string
-	Name     string
-	Type     string
-	Path     string
-	Content  string
-	FilePath string
+	ID            string
+	Name          string
+	Type          string
+	Path          string
+	Content       string
+	FilePath      string
+	SyncTimestamp *time.Time
 }
 
 type deployHTTPClient interface {
@@ -53,11 +53,6 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 
 	fmt.Printf("Deploying dashboards and tasks...\n\n")
 	fmt.Println("Current time: ", time.Now().Format(time.RFC3339))
-	if cfg.LastPull != nil {
-		fmt.Println("Last pulled:  ", cfg.LastPull.Format(time.RFC3339))
-	} else {
-		fmt.Println("Last pulled:  (not set)")
-	}
 	fmt.Println()
 
 	systemCfg, err := fetchSystemConfig(ctx, cfg.URL)
@@ -86,19 +81,6 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 	}
 	fmt.Printf("Found %d remote apps.\n", len(remoteApps))
 
-	// Count app-type apps (dashboard or task)
-	remoteAppCount := 0
-	for _, app := range remoteApps {
-		if app.Type == "dashboard" || app.Type == "task" {
-			remoteAppCount++
-		}
-	}
-
-	// Require lastPull only if remote has apps
-	if remoteAppCount > 0 && cfg.LastPull == nil {
-		return errors.New("config missing lastPull timestamp; run `shaper pull` before deploying (remote has existing apps)")
-	}
-
 	fmt.Println("Loading apps from folder", watchDir)
 	localApps, err := loadLocalApps(watchDir)
 	if err != nil {
@@ -113,11 +95,8 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 		}
 	}
 
-	// Only check freshness if we have a lastPull timestamp
-	if cfg.LastPull != nil {
-		if err := ensureRemoteFreshness(remoteApps, localApps, *cfg.LastPull, client.Actor()); err != nil {
-			return err
-		}
+	if err := ensureRemoteFreshness(remoteApps, localApps, client.Actor()); err != nil {
+		return err
 	}
 
 	ops := buildDeployOperations(localApps, remoteApps)
@@ -179,13 +158,13 @@ func loadLocalApps(baseDir string) (map[string]LocalApp, error) {
 			return fmt.Errorf("failed to read %s: %w", p, err)
 		}
 		content := string(contentBytes)
-		id := extractShaperID(content)
-		if id == "" {
+		meta := extractAppMetadata(content)
+		if meta.ID == "" {
 			return fmt.Errorf("%s is missing a shaper id comment (run `shaper ids` to generate)", p)
 		}
 
-		if _, exists := apps[id]; exists {
-			return fmt.Errorf("duplicate app id %s found in %s and %s", id, apps[id].FilePath, p)
+		if _, exists := apps[meta.ID]; exists {
+			return fmt.Errorf("duplicate app id %s found in %s and %s", meta.ID, apps[meta.ID].FilePath, p)
 		}
 
 		relDir, err := filepath.Rel(baseDir, filepath.Dir(p))
@@ -200,13 +179,14 @@ func loadLocalApps(baseDir string) (map[string]LocalApp, error) {
 			name = strings.TrimSuffix(d.Name(), TASK_SUFFIX)
 		}
 
-		apps[id] = LocalApp{
-			ID:       id,
-			Name:     name,
-			Type:     appType,
-			Path:     normalizeDashboardPath(relDir),
-			Content:  content,
-			FilePath: p,
+		apps[meta.ID] = LocalApp{
+			ID:            meta.ID,
+			Name:          name,
+			Type:          appType,
+			Path:          normalizeDashboardPath(relDir),
+			Content:       content,
+			FilePath:      p,
+			SyncTimestamp: meta.SyncTimestamp,
 		}
 		return nil
 	})
@@ -228,32 +208,31 @@ func normalizeDashboardPath(relDir string) string {
 	return normalized
 }
 
-// stripShaperIDPrefix removes the ID prefix, the newline after it, and the following empty line from content.
-// The ID prefix format is "-- shaperid:<id>\n\n" at the start of the content.
-func stripShaperIDPrefix(content string) string {
-	if !strings.HasPrefix(content, shaperIDPrefix) {
-		return content
+// stripAppMetadata removes the ID and SyncTime prefixes, their newlines, and the following empty line from content.
+func stripAppMetadata(content string) string {
+	lines := strings.Split(content, "\n")
+	var newLines []string
+	inMetadata := true
+	hadMetadata := false
+	for i, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if inMetadata && (strings.HasPrefix(trimmedLine, shaperIDPrefix) || strings.HasPrefix(trimmedLine, shaperSyncPrefix)) {
+			hadMetadata = true
+			continue
+		}
+		if inMetadata {
+			inMetadata = false
+			// Only skip the empty line if we actually stripped some metadata beforehand
+			if hadMetadata && trimmedLine == "" && len(newLines) == 0 && i < len(lines)-1 {
+				continue
+			}
+		}
+		newLines = append(newLines, line)
 	}
-
-	// Find the end of the first line (where the newline is)
-	lineEnd := strings.IndexByte(content, '\n')
-	if lineEnd == -1 {
-		// No newline found, return empty string (content is just the ID line)
-		return ""
-	}
-
-	// Skip the ID line's newline
-	remaining := content[lineEnd+1:]
-
-	// Check if there's an empty line after the ID line and skip it too
-	if len(remaining) > 0 && remaining[0] == '\n' {
-		remaining = remaining[1:]
-	}
-
-	return remaining
+	return strings.Join(newLines, "\n")
 }
 
-func ensureRemoteFreshness(remote []api.App, local map[string]LocalApp, lastPull time.Time, actor string) error {
+func ensureRemoteFreshness(remote []api.App, local map[string]LocalApp, actor string) error {
 	for _, app := range remote {
 		if app.Type != "dashboard" && app.Type != "task" {
 			continue
@@ -270,12 +249,17 @@ func ensureRemoteFreshness(remote []api.App, local map[string]LocalApp, lastPull
 			updatedBy = *app.UpdatedBy
 		}
 
-		// If the app was updated after our last pull, we normally want to force a pull first.
-		// However, we allow overwriting if the update was made by the current actor AND the app exists locally.
-		// The "exists locally" check prevents us from accidentally deleting apps that were created
-		// by the user in the UI (since they won't exist locally yet).
-		if app.UpdatedAt.After(lastPull) && (updatedBy != actor || !exists) {
-			return fmt.Errorf("remote app %s (%s) was updated after last pull by %s; run `shaper pull` first", app.Name, app.ID, updatedBy)
+		// If the app was updated after our local sync timestamp, we normally want to force a pull first.
+		// If no sync timestamp exists locally, we MUST assume it's stale if we want to protect against overwriting Prod.
+		isStale := false
+		if localApp.SyncTimestamp != nil {
+			isStale = app.UpdatedAt.Truncate(time.Second).After(*localApp.SyncTimestamp)
+		} else {
+			isStale = true
+		}
+
+		if isStale {
+			return fmt.Errorf("remote app %s (%s) was updated in prod by %s; run `shaper pull` first", app.Name, app.ID, updatedBy)
 		}
 	}
 	return nil
@@ -309,7 +293,7 @@ func buildDeployOperations(local map[string]LocalApp, remote []api.App) []api.Ap
 			if appsDiffer(localApp, remoteApp) {
 				name := localApp.Name
 				path := localApp.Path
-				content := stripShaperIDPrefix(localApp.Content)
+				content := stripAppMetadata(localApp.Content)
 				id := localApp.ID
 				updateOps = append(updateOps, api.AppRequest{
 					Operation: "update",
@@ -327,7 +311,7 @@ func buildDeployOperations(local map[string]LocalApp, remote []api.App) []api.Ap
 
 		name := localApp.Name
 		path := localApp.Path
-		content := stripShaperIDPrefix(localApp.Content)
+		content := stripAppMetadata(localApp.Content)
 		id := localApp.ID
 		createOps = append(createOps, api.AppRequest{
 			Operation: "create",
@@ -382,7 +366,7 @@ func appsDiffer(local LocalApp, remote api.App) bool {
 		return true
 	}
 	// Compare content without the ID prefix (local has it, remote doesn't)
-	localContent := stripShaperIDPrefix(local.Content)
+	localContent := stripAppMetadata(local.Content)
 	return localContent != remote.Content
 }
 

--- a/server/dev/deploy.go
+++ b/server/dev/deploy.go
@@ -115,7 +115,7 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 
 	// Only check freshness if we have a lastPull timestamp
 	if cfg.LastPull != nil {
-		if err := ensureRemoteFreshness(remoteApps, *cfg.LastPull, client.Actor()); err != nil {
+		if err := ensureRemoteFreshness(remoteApps, localApps, *cfg.LastPull, client.Actor()); err != nil {
 			return err
 		}
 	}
@@ -253,16 +253,28 @@ func stripShaperIDPrefix(content string) string {
 	return remaining
 }
 
-func ensureRemoteFreshness(remote []api.App, lastPull time.Time, actor string) error {
+func ensureRemoteFreshness(remote []api.App, local map[string]LocalApp, lastPull time.Time, actor string) error {
 	for _, app := range remote {
 		if app.Type != "dashboard" && app.Type != "task" {
 			continue
 		}
+
+		localApp, exists := local[app.ID]
+		willBeModified := !exists || appsDiffer(localApp, app)
+		if !willBeModified {
+			continue
+		}
+
 		updatedBy := ""
 		if app.UpdatedBy != nil {
 			updatedBy = *app.UpdatedBy
 		}
-		if app.UpdatedAt.After(lastPull) && updatedBy != actor {
+
+		// If the app was updated after our last pull, we normally want to force a pull first.
+		// However, we allow overwriting if the update was made by the current actor AND the app exists locally.
+		// The "exists locally" check prevents us from accidentally deleting apps that were created
+		// by the user in the UI (since they won't exist locally yet).
+		if app.UpdatedAt.After(lastPull) && (updatedBy != actor || !exists) {
 			return fmt.Errorf("remote app %s (%s) was updated after last pull by %s; run `shaper pull` first", app.Name, app.ID, updatedBy)
 		}
 	}

--- a/server/dev/deploy.go
+++ b/server/dev/deploy.go
@@ -181,7 +181,7 @@ func loadLocalApps(baseDir string) (map[string]LocalApp, error) {
 		content := string(contentBytes)
 		id := extractShaperID(content)
 		if id == "" {
-			return fmt.Errorf("%s is missing a shaper id comment (-- shaperid:<id>)", p)
+			return fmt.Errorf("%s is missing a shaper id comment (run `shaper ids` to generate)", p)
 		}
 
 		if _, exists := apps[id]; exists {
@@ -277,7 +277,9 @@ func buildDeployOperations(local map[string]LocalApp, remote []api.App) []api.Ap
 		}
 	}
 
-	var ops []api.AppRequest
+	var createOps []api.AppRequest
+	var updateOps []api.AppRequest
+	var deleteOps []api.AppRequest
 
 	localList := make([]LocalApp, 0, len(local))
 	for _, l := range local {
@@ -297,7 +299,7 @@ func buildDeployOperations(local map[string]LocalApp, remote []api.App) []api.Ap
 				path := localApp.Path
 				content := stripShaperIDPrefix(localApp.Content)
 				id := localApp.ID
-				ops = append(ops, api.AppRequest{
+				updateOps = append(updateOps, api.AppRequest{
 					Operation: "update",
 					Type:      localApp.Type,
 					Data: api.DashboardData{
@@ -315,7 +317,7 @@ func buildDeployOperations(local map[string]LocalApp, remote []api.App) []api.Ap
 		path := localApp.Path
 		content := stripShaperIDPrefix(localApp.Content)
 		id := localApp.ID
-		ops = append(ops, api.AppRequest{
+		createOps = append(createOps, api.AppRequest{
 			Operation: "create",
 			Type:      localApp.Type,
 			Data: api.DashboardData{
@@ -343,7 +345,7 @@ func buildDeployOperations(local map[string]LocalApp, remote []api.App) []api.Ap
 			continue
 		}
 		id := remoteApp.ID
-		ops = append(ops, api.AppRequest{
+		deleteOps = append(deleteOps, api.AppRequest{
 			Operation: "delete",
 			Type:      remoteApp.Type,
 			Data: api.DashboardData{
@@ -351,6 +353,11 @@ func buildDeployOperations(local map[string]LocalApp, remote []api.App) []api.Ap
 			},
 		})
 	}
+
+	var ops []api.AppRequest
+	ops = append(ops, deleteOps...)
+	ops = append(ops, updateOps...)
+	ops = append(ops, createOps...)
 
 	return ops
 }

--- a/server/dev/deploy.go
+++ b/server/dev/deploy.go
@@ -23,9 +23,10 @@ const (
 	noAuthActor     = "no_auth"
 )
 
-type LocalDashboard struct {
+type LocalApp struct {
 	ID       string
 	Name     string
+	Type     string
 	Path     string
 	Content  string
 	FilePath string
@@ -50,7 +51,7 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 		return err
 	}
 
-	fmt.Printf("Deploying Shaper dashboards...\n\n")
+	fmt.Printf("Deploying dashboards and tasks...\n\n")
 	fmt.Println("Current time: ", time.Now().Format(time.RFC3339))
 	if cfg.LastPull != nil {
 		fmt.Println("Last pulled:  ", cfg.LastPull.Format(time.RFC3339))
@@ -78,48 +79,48 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 	default:
 		return fmt.Errorf("%s must be set to run shaper deploy when login is required", deployAPIKeyEnv)
 	}
-	fmt.Println("Fetching remote dashboards from", cfg.URL)
-	remoteDashboards, err := fetchAllDashboards(ctx, client)
+	fmt.Println("Fetching remote apps from", cfg.URL)
+	remoteApps, err := fetchAllApps(ctx, client)
 	if err != nil {
-		return fmt.Errorf("failed to fetch dashboards: %w", err)
+		return fmt.Errorf("failed to fetch apps: %w", err)
 	}
-	fmt.Printf("Found %d remote dashboards.\n", len(remoteDashboards))
+	fmt.Printf("Found %d remote apps.\n", len(remoteApps))
 
-	// Count dashboard-type apps
-	remoteDashboardCount := 0
-	for _, dashboard := range remoteDashboards {
-		if dashboard.Type == "dashboard" {
-			remoteDashboardCount++
+	// Count app-type apps (dashboard or task)
+	remoteAppCount := 0
+	for _, app := range remoteApps {
+		if app.Type == "dashboard" || app.Type == "task" {
+			remoteAppCount++
 		}
 	}
 
-	// Require lastPull only if remote has dashboards
-	if remoteDashboardCount > 0 && cfg.LastPull == nil {
-		return errors.New("config missing lastPull timestamp; run `shaper pull` before deploying (remote has existing dashboards)")
+	// Require lastPull only if remote has apps
+	if remoteAppCount > 0 && cfg.LastPull == nil {
+		return errors.New("config missing lastPull timestamp; run `shaper pull` before deploying (remote has existing apps)")
 	}
 
-	fmt.Println("Loading dashboards from folder", watchDir)
-	localDashboards, err := loadLocalDashboards(watchDir)
+	fmt.Println("Loading apps from folder", watchDir)
+	localApps, err := loadLocalApps(watchDir)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Found %d local dashboards.\n", len(localDashboards))
+	fmt.Printf("Found %d local apps.\n", len(localApps))
 
-	remoteDashboardsByID := make(map[string]api.App, len(remoteDashboards))
-	for _, dashboard := range remoteDashboards {
-		if dashboard.Type == "dashboard" {
-			remoteDashboardsByID[dashboard.ID] = dashboard
+	remoteAppsByID := make(map[string]api.App, len(remoteApps))
+	for _, app := range remoteApps {
+		if app.Type == "dashboard" || app.Type == "task" {
+			remoteAppsByID[app.ID] = app
 		}
 	}
 
 	// Only check freshness if we have a lastPull timestamp
 	if cfg.LastPull != nil {
-		if err := ensureRemoteFreshness(remoteDashboards, *cfg.LastPull, client.Actor()); err != nil {
+		if err := ensureRemoteFreshness(remoteApps, *cfg.LastPull, client.Actor()); err != nil {
 			return err
 		}
 	}
 
-	ops := buildDeployOperations(localDashboards, remoteDashboards)
+	ops := buildDeployOperations(localApps, remoteApps)
 	if len(ops) == 0 {
 		fmt.Printf("\nNo changes detected; nothing to deploy.\n")
 		return nil
@@ -138,7 +139,7 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 	}
 
 	fmt.Printf("\nChanges: create=%d, update=%d, delete=%d\n\n", createCount, updateCount, deleteCount)
-	logDeployChanges(ops, localDashboards, remoteDashboardsByID)
+	logDeployChanges(ops, localApps, remoteAppsByID)
 
 	if validateOnly {
 		fmt.Printf("\nValidation successful. No changes have been applied (validate-only mode).\n")
@@ -153,8 +154,8 @@ func RunDeployCommand(ctx context.Context, configPath string, validateOnly bool)
 	return nil
 }
 
-func loadLocalDashboards(baseDir string) (map[string]LocalDashboard, error) {
-	dashboards := make(map[string]LocalDashboard)
+func loadLocalApps(baseDir string) (map[string]LocalApp, error) {
+	apps := make(map[string]LocalApp)
 	err := filepath.WalkDir(baseDir, func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -162,9 +163,13 @@ func loadLocalDashboards(baseDir string) (map[string]LocalDashboard, error) {
 		if d.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX) {
+
+		isDashboard := strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX)
+		isTask := strings.HasSuffix(d.Name(), TASK_SUFFIX)
+
+		if !isDashboard && !isTask {
 			if strings.HasSuffix(d.Name(), ".sql") {
-				fmt.Printf("WARNING: %s ends with .sql but not with %s; ignoring\n", p, DASHBOARD_SUFFIX)
+				fmt.Printf("WARNING: %s ends with .sql but not with %s or %s; ignoring\n", p, DASHBOARD_SUFFIX, TASK_SUFFIX)
 			}
 			return nil
 		}
@@ -179,8 +184,8 @@ func loadLocalDashboards(baseDir string) (map[string]LocalDashboard, error) {
 			return fmt.Errorf("%s is missing a shaper id comment (-- shaperid:<id>)", p)
 		}
 
-		if _, exists := dashboards[id]; exists {
-			return fmt.Errorf("duplicate dashboard id %s found in %s and %s", id, dashboards[id].FilePath, p)
+		if _, exists := apps[id]; exists {
+			return fmt.Errorf("duplicate app id %s found in %s and %s", id, apps[id].FilePath, p)
 		}
 
 		relDir, err := filepath.Rel(baseDir, filepath.Dir(p))
@@ -188,9 +193,17 @@ func loadLocalDashboards(baseDir string) (map[string]LocalDashboard, error) {
 			return fmt.Errorf("failed to determine relative path for %s: %w", p, err)
 		}
 
-		dashboards[id] = LocalDashboard{
+		appType := "dashboard"
+		name := strings.TrimSuffix(d.Name(), DASHBOARD_SUFFIX)
+		if isTask {
+			appType = "task"
+			name = strings.TrimSuffix(d.Name(), TASK_SUFFIX)
+		}
+
+		apps[id] = LocalApp{
 			ID:       id,
-			Name:     strings.TrimSuffix(d.Name(), DASHBOARD_SUFFIX),
+			Name:     name,
+			Type:     appType,
 			Path:     normalizeDashboardPath(relDir),
 			Content:  content,
 			FilePath: p,
@@ -198,7 +211,7 @@ func loadLocalDashboards(baseDir string) (map[string]LocalDashboard, error) {
 		return nil
 	})
 
-	return dashboards, err
+	return apps, err
 }
 
 func normalizeDashboardPath(relDir string) string {
@@ -241,32 +254,32 @@ func stripShaperIDPrefix(content string) string {
 }
 
 func ensureRemoteFreshness(remote []api.App, lastPull time.Time, actor string) error {
-	for _, dashboard := range remote {
-		if dashboard.Type != "dashboard" {
+	for _, app := range remote {
+		if app.Type != "dashboard" && app.Type != "task" {
 			continue
 		}
 		updatedBy := ""
-		if dashboard.UpdatedBy != nil {
-			updatedBy = *dashboard.UpdatedBy
+		if app.UpdatedBy != nil {
+			updatedBy = *app.UpdatedBy
 		}
-		if dashboard.UpdatedAt.After(lastPull) && updatedBy != actor {
-			return fmt.Errorf("remote dashboard %s (%s) was updated after last pull by %s; run `shaper pull` first", dashboard.Name, dashboard.ID, updatedBy)
+		if app.UpdatedAt.After(lastPull) && updatedBy != actor {
+			return fmt.Errorf("remote app %s (%s) was updated after last pull by %s; run `shaper pull` first", app.Name, app.ID, updatedBy)
 		}
 	}
 	return nil
 }
 
-func buildDeployOperations(local map[string]LocalDashboard, remote []api.App) []api.AppRequest {
+func buildDeployOperations(local map[string]LocalApp, remote []api.App) []api.AppRequest {
 	remoteByID := make(map[string]api.App, len(remote))
 	for _, r := range remote {
-		if r.Type == "dashboard" {
+		if r.Type == "dashboard" || r.Type == "task" {
 			remoteByID[r.ID] = r
 		}
 	}
 
 	var ops []api.AppRequest
 
-	localList := make([]LocalDashboard, 0, len(local))
+	localList := make([]LocalApp, 0, len(local))
 	for _, l := range local {
 		localList = append(localList, l)
 	}
@@ -277,16 +290,16 @@ func buildDeployOperations(local map[string]LocalDashboard, remote []api.App) []
 		return localList[i].Path < localList[j].Path
 	})
 
-	for _, localDash := range localList {
-		if remoteDash, ok := remoteByID[localDash.ID]; ok {
-			if dashboardsDiffer(localDash, remoteDash) {
-				name := localDash.Name
-				path := localDash.Path
-				content := stripShaperIDPrefix(localDash.Content)
-				id := localDash.ID
+	for _, localApp := range localList {
+		if remoteApp, ok := remoteByID[localApp.ID]; ok {
+			if appsDiffer(localApp, remoteApp) {
+				name := localApp.Name
+				path := localApp.Path
+				content := stripShaperIDPrefix(localApp.Content)
+				id := localApp.ID
 				ops = append(ops, api.AppRequest{
 					Operation: "update",
-					Type:      "dashboard",
+					Type:      localApp.Type,
 					Data: api.DashboardData{
 						ID:      &id,
 						Name:    &name,
@@ -298,13 +311,13 @@ func buildDeployOperations(local map[string]LocalDashboard, remote []api.App) []
 			continue
 		}
 
-		name := localDash.Name
-		path := localDash.Path
-		content := stripShaperIDPrefix(localDash.Content)
-		id := localDash.ID
+		name := localApp.Name
+		path := localApp.Path
+		content := stripShaperIDPrefix(localApp.Content)
+		id := localApp.ID
 		ops = append(ops, api.AppRequest{
 			Operation: "create",
-			Type:      "dashboard",
+			Type:      localApp.Type,
 			Data: api.DashboardData{
 				ID:      &id,
 				Name:    &name,
@@ -325,14 +338,14 @@ func buildDeployOperations(local map[string]LocalDashboard, remote []api.App) []
 		return remoteList[i].Path < remoteList[j].Path
 	})
 
-	for _, remoteDash := range remoteList {
-		if _, ok := local[remoteDash.ID]; ok {
+	for _, remoteApp := range remoteList {
+		if _, ok := local[remoteApp.ID]; ok {
 			continue
 		}
-		id := remoteDash.ID
+		id := remoteApp.ID
 		ops = append(ops, api.AppRequest{
 			Operation: "delete",
-			Type:      "dashboard",
+			Type:      remoteApp.Type,
 			Data: api.DashboardData{
 				ID: &id,
 			},
@@ -342,7 +355,7 @@ func buildDeployOperations(local map[string]LocalDashboard, remote []api.App) []
 	return ops
 }
 
-func dashboardsDiffer(local LocalDashboard, remote api.App) bool {
+func appsDiffer(local LocalApp, remote api.App) bool {
 	if local.Name != remote.Name {
 		return true
 	}
@@ -354,17 +367,19 @@ func dashboardsDiffer(local LocalDashboard, remote api.App) bool {
 	return localContent != remote.Content
 }
 
-func logDeployChanges(ops []api.AppRequest, local map[string]LocalDashboard, remote map[string]api.App) {
+func logDeployChanges(ops []api.AppRequest, local map[string]LocalApp, remote map[string]api.App) {
 	for _, op := range ops {
 		var (
 			currentPath string
 			currentName string
+			appType     string
 		)
 
 		if op.Data.ID != nil {
-			if localDash, ok := local[*op.Data.ID]; ok {
-				currentPath = localDash.Path
-				currentName = localDash.Name
+			if localApp, ok := local[*op.Data.ID]; ok {
+				currentPath = localApp.Path
+				currentName = localApp.Name
+				appType = localApp.Type
 			}
 		}
 		if currentPath == "" && op.Data.Path != nil {
@@ -372,6 +387,9 @@ func logDeployChanges(ops []api.AppRequest, local map[string]LocalDashboard, rem
 		}
 		if currentName == "" && op.Data.Name != nil {
 			currentName = *op.Data.Name
+		}
+		if appType == "" {
+			appType = op.Type
 		}
 
 		var prev api.App
@@ -384,6 +402,9 @@ func logDeployChanges(ops []api.AppRequest, local map[string]LocalDashboard, rem
 		}
 		if currentName == "" && hasPrev {
 			currentName = prev.Name
+		}
+		if appType == "" && hasPrev {
+			appType = prev.Type
 		}
 
 		extra := ""
@@ -402,7 +423,13 @@ func logDeployChanges(ops []api.AppRequest, local map[string]LocalDashboard, rem
 		if op.Data.ID != nil {
 			opID = *op.Data.ID
 		}
-		fmt.Printf("%s %s: %s%s%s%s\n", op.Operation, opID, currentPath, currentName, DASHBOARD_SUFFIX, extra)
+
+		suffix := DASHBOARD_SUFFIX
+		if appType == "task" {
+			suffix = TASK_SUFFIX
+		}
+
+		fmt.Printf("%s %s: %s%s%s%s\n", op.Operation, opID, currentPath, currentName, suffix, extra)
 	}
 }
 

--- a/server/dev/dev.go
+++ b/server/dev/dev.go
@@ -15,7 +15,7 @@ func RunDevCommand(ctx context.Context, configPath, authFile string) error {
 		return err
 	}
 
-	watchDir, err := resolveAbsolutePath(cfg.Directory)
+	watchDir, err := resolveConfigDirectory(cfg.Directory, configPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve watch directory: %w", err)
 	}

--- a/server/dev/ids.go
+++ b/server/dev/ids.go
@@ -21,7 +21,7 @@ func RunIdsCommand(ctx context.Context, configPath string) error {
 		return err
 	}
 
-	fmt.Printf("Adding missing IDs to dashboards in %s...\n", watchDir)
+	fmt.Printf("Adding missing IDs to apps in %s...\n", watchDir)
 
 	fileCount, err := ensureShaperIDsForDir(watchDir)
 	if err != nil {
@@ -32,7 +32,7 @@ func RunIdsCommand(ctx context.Context, configPath string) error {
 	if fileCount != 1 {
 		pluralSuffix = "s"
 	}
-	fmt.Printf("\nDone. Processed %d dashboard%s.\n", fileCount, pluralSuffix)
+	fmt.Printf("\nDone. Processed %d app%s.\n", fileCount, pluralSuffix)
 
 	return nil
 }

--- a/server/dev/ids.go
+++ b/server/dev/ids.go
@@ -13,7 +13,7 @@ func RunIdsCommand(ctx context.Context, configPath string) error {
 		return err
 	}
 
-	watchDir, err := resolveAbsolutePath(cfg.Directory)
+	watchDir, err := resolveConfigDirectory(cfg.Directory, configPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve directory: %w", err)
 	}

--- a/server/dev/pathutil.go
+++ b/server/dev/pathutil.go
@@ -55,3 +55,26 @@ func resolveAbsolutePath(p string) (string, error) {
 	}
 	return absPath, nil
 }
+
+// resolveConfigDirectory resolves a directory path relative to the given config file path.
+func resolveConfigDirectory(dir string, configPath string) (string, error) {
+	expanded, err := expandUserPath(dir)
+	if err != nil {
+		return "", err
+	}
+	if expanded == "" {
+		return "", nil
+	}
+
+	if filepath.IsAbs(expanded) {
+		return filepath.Clean(expanded), nil
+	}
+
+	absConfigPath, err := resolveAbsolutePath(configPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve config path: %w", err)
+	}
+
+	configDir := filepath.Dir(absConfigPath)
+	return filepath.Join(configDir, expanded), nil
+}

--- a/server/dev/pull.go
+++ b/server/dev/pull.go
@@ -79,23 +79,11 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 
 	// Compare and categorize
 	var toCreate, toUpdate []api.App
-	var maxUpdatedAt time.Time
-
-	// Track max updatedAt from folders as well
-	for _, folder := range folders {
-		if folder.UpdatedAt.After(maxUpdatedAt) {
-			maxUpdatedAt = folder.UpdatedAt
-		}
-	}
-
+	
 	// Track file paths to detect duplicates
 	seenPaths := make(map[string]string) // path -> app name (for error reporting)
 
 	for _, app := range remoteApps {
-		if app.UpdatedAt.After(maxUpdatedAt) {
-			maxUpdatedAt = app.UpdatedAt
-		}
-
 		// Check for duplicate file paths
 		suffix := DASHBOARD_SUFFIX
 		if app.Type == "task" {
@@ -107,25 +95,49 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 		}
 		seenPaths[filePath] = app.Name
 
-		// Check if app itself was updated
-		appUpdated := cfg.LastPull == nil || app.UpdatedAt.After(*cfg.LastPull)
+		localPath, existsLocally := localIDs[app.ID]
 
-		// Check if any folder in the app's path was updated
-		folderUpdated := false
-		if cfg.LastPull != nil {
-			folderUpdated = isAnyParentFolderUpdated(app.Path, folderUpdatedAt, *cfg.LastPull)
-		}
-
-		// Include app if it was updated OR if any parent folder was updated
-		if !appUpdated && !folderUpdated {
+		if !existsLocally {
+			toCreate = append(toCreate, app)
 			continue
 		}
 
-		if _, exists := localIDs[app.ID]; exists {
-			toUpdate = append(toUpdate, app)
-		} else {
-			toCreate = append(toCreate, app)
+		// Read local file to check SyncTimestamp and content
+		contentBytes, err := os.ReadFile(localPath)
+		if err != nil {
+			return fmt.Errorf("failed to read local file %s: %w", localPath, err)
 		}
+		
+		content := string(contentBytes)
+		meta := extractAppMetadata(content)
+		
+		// Reconstruct what the local app looks like to check if it differs
+		relDir, err := filepath.Rel(watchDir, filepath.Dir(localPath))
+		if err != nil {
+			return fmt.Errorf("failed to determine relative path for %s: %w", localPath, err)
+		}
+		
+		name := strings.TrimSuffix(filepath.Base(localPath), DASHBOARD_SUFFIX)
+		if app.Type == "task" {
+			name = strings.TrimSuffix(filepath.Base(localPath), TASK_SUFFIX)
+		}
+
+		localApp := LocalApp{
+			ID:            meta.ID,
+			Name:          name,
+			Path:          normalizeDashboardPath(relDir),
+			Content:       content,
+			SyncTimestamp: meta.SyncTimestamp,
+		}
+
+		// We MUST update the local file if it lacks a SyncTimestamp, OR if it's stale, OR if it differs.
+		// Without a SyncTimestamp, `deploy` cannot safely protect against overwriting manual Prod changes.
+		isStale := meta.SyncTimestamp == nil || app.UpdatedAt.Truncate(time.Second).After(*meta.SyncTimestamp)
+		if isStale || appsDiffer(localApp, app) {
+			toUpdate = append(toUpdate, app)
+		}
+
+		delete(localIDs, app.ID)
 	}
 
 	if len(toCreate) == 0 && len(toUpdate) == 0 {
@@ -251,13 +263,7 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 		return fmt.Errorf("pull completed with %d deletion error(s), lastPull not updated", len(deleteErrors))
 	}
 
-	// Update lastPull timestamp
-	cfg.LastPull = &maxUpdatedAt
-	if err := SaveConfig(configPath, cfg); err != nil {
-		return fmt.Errorf("failed to save config with lastPull: %w", err)
-	}
-
-	fmt.Printf("\nPull complete. Last pull timestamp: %s\n", maxUpdatedAt.Format(time.RFC3339))
+	fmt.Printf("\nPull complete.\n")
 	return nil
 }
 
@@ -470,11 +476,15 @@ func writeAppFile(baseDir string, app api.App) error {
 	fileName := sanitizeFileName(app.Name) + suffix
 	filePath := filepath.Join(dirPath, fileName)
 
-	// Ensure content has shaper ID
-	content := app.Content
-	if !hasLeadingShaperIDComment(content) {
-		content = prependShaperIDComment(app.ID, content)
+	meta := extractAppMetadata(app.Content)
+	if meta.ID == "" {
+		meta.ID = app.ID
 	}
+	
+	// We want to format the time without nanoseconds so that when we read it back and compare, 
+	// it isn't automatically considered "stale" due to nanosecond precision loss during formatting.
+	truncatedTime := app.UpdatedAt.Truncate(time.Second)
+	content := prependAppMetadata(meta.ID, &truncatedTime, stripAppMetadata(app.Content))
 
 	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("failed to write file %s: %w", filePath, err)

--- a/server/dev/pull.go
+++ b/server/dev/pull.go
@@ -37,7 +37,7 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 		return fmt.Errorf("failed to resolve auth file path: %w", err)
 	}
 
-	fmt.Printf("Pulling dashboard changes...\n\n")
+	fmt.Printf("Pulling app changes...\n\n")
 
 	systemCfg, err := fetchSystemConfig(ctx, cfg.URL)
 	if err != nil {
@@ -54,13 +54,13 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 		return fmt.Errorf("failed to initialize API client: %w", err)
 	}
 
-	// Fetch all dashboards and folders from remote
-	fmt.Println("Fetching dashboards and folders from", cfg.URL)
-	remoteDashboards, folders, err := fetchAllDashboardsAndFolders(ctx, client)
+	// Fetch all apps and folders from remote
+	fmt.Println("Fetching apps and folders from", cfg.URL)
+	remoteApps, folders, err := fetchAllAppsAndFolders(ctx, client)
 	if err != nil {
-		return fmt.Errorf("failed to fetch dashboards: %w", err)
+		return fmt.Errorf("failed to fetch apps: %w", err)
 	}
-	fmt.Printf("Found %d remote dashboards\n", len(remoteDashboards))
+	fmt.Printf("Found %d remote apps\n", len(remoteApps))
 	fmt.Printf("Found %d remote folders\n", len(folders))
 
 	// Build a map of folder paths to their updatedAt timestamps
@@ -69,13 +69,13 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 		folderUpdatedAt[folder.Path+folder.Name+"/"] = folder.UpdatedAt
 	}
 
-	// Scan local files for existing dashboard IDs
-	fmt.Println("Loading dashboards from folder", watchDir)
-	localIDs, err := scanLocalDashboardIDs(watchDir)
+	// Scan local files for existing app IDs
+	fmt.Println("Loading apps from folder", watchDir)
+	localIDs, err := scanLocalAppIDs(watchDir)
 	if err != nil {
-		return fmt.Errorf("failed to scan local dashboards: %w", err)
+		return fmt.Errorf("failed to scan local apps: %w", err)
 	}
-	fmt.Printf("Found %d local dashboards.\n", len(localIDs))
+	fmt.Printf("Found %d local apps.\n", len(localIDs))
 
 	// Compare and categorize
 	var toCreate, toUpdate []api.App
@@ -89,38 +89,42 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 	}
 
 	// Track file paths to detect duplicates
-	seenPaths := make(map[string]string) // path -> dashboard name (for error reporting)
+	seenPaths := make(map[string]string) // path -> app name (for error reporting)
 
-	for _, dashboard := range remoteDashboards {
-		if dashboard.UpdatedAt.After(maxUpdatedAt) {
-			maxUpdatedAt = dashboard.UpdatedAt
+	for _, app := range remoteApps {
+		if app.UpdatedAt.After(maxUpdatedAt) {
+			maxUpdatedAt = app.UpdatedAt
 		}
 
 		// Check for duplicate file paths
-		filePath := filepath.Join(strings.TrimPrefix(dashboard.Path, "/"), sanitizeFileName(dashboard.Name)+DASHBOARD_SUFFIX)
-		if existingName, exists := seenPaths[filePath]; exists {
-			return fmt.Errorf("duplicate dashboard name %q in folder %q (conflicts with %q) - please rename one of them before pulling", dashboard.Name, dashboard.Path, existingName)
+		suffix := DASHBOARD_SUFFIX
+		if app.Type == "task" {
+			suffix = TASK_SUFFIX
 		}
-		seenPaths[filePath] = dashboard.Name
+		filePath := filepath.Join(strings.TrimPrefix(app.Path, "/"), sanitizeFileName(app.Name)+suffix)
+		if existingName, exists := seenPaths[filePath]; exists {
+			return fmt.Errorf("duplicate app name %q in folder %q (conflicts with %q) - please rename one of them before pulling", app.Name, app.Path, existingName)
+		}
+		seenPaths[filePath] = app.Name
 
-		// Check if dashboard itself was updated
-		dashboardUpdated := cfg.LastPull == nil || dashboard.UpdatedAt.After(*cfg.LastPull)
+		// Check if app itself was updated
+		appUpdated := cfg.LastPull == nil || app.UpdatedAt.After(*cfg.LastPull)
 
-		// Check if any folder in the dashboard's path was updated
+		// Check if any folder in the app's path was updated
 		folderUpdated := false
 		if cfg.LastPull != nil {
-			folderUpdated = isAnyParentFolderUpdated(dashboard.Path, folderUpdatedAt, *cfg.LastPull)
+			folderUpdated = isAnyParentFolderUpdated(app.Path, folderUpdatedAt, *cfg.LastPull)
 		}
 
-		// Include dashboard if it was updated OR if any parent folder was updated
-		if !dashboardUpdated && !folderUpdated {
+		// Include app if it was updated OR if any parent folder was updated
+		if !appUpdated && !folderUpdated {
 			continue
 		}
 
-		if _, exists := localIDs[dashboard.ID]; exists {
-			toUpdate = append(toUpdate, dashboard)
+		if _, exists := localIDs[app.ID]; exists {
+			toUpdate = append(toUpdate, app)
 		} else {
-			toCreate = append(toCreate, dashboard)
+			toCreate = append(toCreate, app)
 		}
 	}
 
@@ -132,15 +136,23 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 	// Show summary
 	fmt.Println()
 	if len(toCreate) > 0 {
-		fmt.Printf("Dashboards to create (%d):\n", len(toCreate))
+		fmt.Printf("Apps to create (%d):\n", len(toCreate))
 		for _, d := range toCreate {
-			fmt.Printf("  + %s%s\n", filepath.Join(strings.TrimPrefix(d.Path, "/"), d.Name), DASHBOARD_SUFFIX)
+			suffix := DASHBOARD_SUFFIX
+			if d.Type == "task" {
+				suffix = TASK_SUFFIX
+			}
+			fmt.Printf("  + %s%s\n", filepath.Join(strings.TrimPrefix(d.Path, "/"), d.Name), suffix)
 		}
 	}
 	if len(toUpdate) > 0 {
-		fmt.Printf("Dashboards to update (%d):\n", len(toUpdate))
+		fmt.Printf("Apps to update (%d):\n", len(toUpdate))
 		for _, d := range toUpdate {
-			fmt.Printf("  + %s%s\n", filepath.Join(strings.TrimPrefix(d.Path, "/"), d.Name), DASHBOARD_SUFFIX)
+			suffix := DASHBOARD_SUFFIX
+			if d.Type == "task" {
+				suffix = TASK_SUFFIX
+			}
+			fmt.Printf("  + %s%s\n", filepath.Join(strings.TrimPrefix(d.Path, "/"), d.Name), suffix)
 		}
 	}
 	fmt.Println()
@@ -188,24 +200,28 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 		}
 	}
 
-	// Write dashboards to files
+	// Write apps to files
 	var writeErrors []error
-	expectedPaths := make(map[string]string) // dashboard ID -> expected file path
-	for _, dashboard := range append(toCreate, toUpdate...) {
-		expectedPath, err := getExpectedFilePath(watchDir, dashboard)
+	expectedPaths := make(map[string]string) // app ID -> expected file path
+	for _, app := range append(toCreate, toUpdate...) {
+		expectedPath, err := getExpectedFilePath(watchDir, app)
 		if err != nil {
-			fmt.Printf("ERROR: Failed to determine file path for dashboard '%s': %s\n", dashboard.Name, err)
+			fmt.Printf("ERROR: Failed to determine file path for app '%s': %s\n", app.Name, err)
 			writeErrors = append(writeErrors, err)
 			continue
 		}
-		expectedPaths[dashboard.ID] = expectedPath
+		expectedPaths[app.ID] = expectedPath
 
-		if err := writeDashboardFile(watchDir, dashboard); err != nil {
-			fmt.Printf("ERROR: Failed to write dashboard '%s': %s\n", dashboard.Name, err)
+		if err := writeAppFile(watchDir, app); err != nil {
+			fmt.Printf("ERROR: Failed to write app '%s': %s\n", app.Name, err)
 			writeErrors = append(writeErrors, err)
 			continue
 		}
-		fmt.Println("Wrote dashboard:", dashboard.Path+dashboard.Name+DASHBOARD_SUFFIX)
+		suffix := DASHBOARD_SUFFIX
+		if app.Type == "task" {
+			suffix = TASK_SUFFIX
+		}
+		fmt.Println("Wrote app:", app.Path+app.Name+suffix)
 	}
 
 	if len(writeErrors) > 0 {
@@ -214,19 +230,19 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 
 	// Delete old files that have been moved or renamed
 	var deleteErrors []error
-	for dashboardID, actualPath := range localIDs {
-		expectedPath, exists := expectedPaths[dashboardID]
+	for appID, actualPath := range localIDs {
+		expectedPath, exists := expectedPaths[appID]
 		if !exists {
-			// Dashboard was deleted remotely, skip deletion (user might want to keep it)
+			// App was deleted remotely, skip deletion (user might want to keep it)
 			continue
 		}
 		if actualPath != expectedPath {
-			// Dashboard was moved/renamed, delete old file
+			// App was moved/renamed, delete old file
 			if err := os.Remove(actualPath); err != nil {
-				fmt.Printf("ERROR: Failed to delete old dashboard file '%s': %s\n", actualPath, err)
+				fmt.Printf("ERROR: Failed to delete old app file '%s': %s\n", actualPath, err)
 				deleteErrors = append(deleteErrors, err)
 			} else {
-				fmt.Printf("Deleted old dashboard file: %s\n", actualPath)
+				fmt.Printf("Deleted old app file: %s\n", actualPath)
 			}
 		}
 	}
@@ -245,13 +261,13 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 	return nil
 }
 
-func fetchAllDashboards(ctx context.Context, requester appsRequester) ([]api.App, error) {
-	dashboards, _, err := fetchAllDashboardsAndFolders(ctx, requester)
-	return dashboards, err
+func fetchAllApps(ctx context.Context, requester appsRequester) ([]api.App, error) {
+	apps, _, err := fetchAllAppsAndFolders(ctx, requester)
+	return apps, err
 }
 
-func fetchAllDashboardsAndFolders(ctx context.Context, requester appsRequester) ([]api.App, []api.App, error) {
-	var allDashboards []api.App
+func fetchAllAppsAndFolders(ctx context.Context, requester appsRequester) ([]api.App, []api.App, error) {
+	var allApps []api.App
 	var allFolders []api.App
 	limit := 100
 	offset := 0
@@ -263,8 +279,8 @@ func fetchAllDashboardsAndFolders(ctx context.Context, requester appsRequester) 
 		}
 
 		for _, app := range apps {
-			if app.Type == "dashboard" {
-				allDashboards = append(allDashboards, app)
+			if app.Type == "dashboard" || app.Type == "task" {
+				allApps = append(allApps, app)
 			} else if app.Type == "_folder" {
 				allFolders = append(allFolders, app)
 			}
@@ -274,10 +290,10 @@ func fetchAllDashboardsAndFolders(ctx context.Context, requester appsRequester) 
 		if len(apps) < limit {
 			break
 		}
-		offset += len(apps)
+		offset += limit
 	}
 
-	return allDashboards, allFolders, nil
+	return allApps, allFolders, nil
 }
 
 func fetchAppsPage(ctx context.Context, requester appsRequester, limit, offset int) ([]api.App, error) {
@@ -300,7 +316,7 @@ func fetchAppsPage(ctx context.Context, requester appsRequester, limit, offset i
 	return result.Apps, nil
 }
 
-func scanLocalDashboardIDs(dir string) (map[string]string, error) {
+func scanLocalAppIDs(dir string) (map[string]string, error) {
 	ids := make(map[string]string) // shaperID -> filePath
 
 	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, walkErr error) error {
@@ -310,9 +326,12 @@ func scanLocalDashboardIDs(dir string) (map[string]string, error) {
 		if d.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX) {
+		isDashboard := strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX)
+		isTask := strings.HasSuffix(d.Name(), TASK_SUFFIX)
+		
+		if !isDashboard && !isTask {
 			if strings.HasSuffix(d.Name(), ".sql") {
-				fmt.Printf("WARNING: %s ends with .sql but not with %s; ignoring\n", p, DASHBOARD_SUFFIX)
+				fmt.Printf("WARNING: %s ends with .sql but not with %s or %s; ignoring\n", p, DASHBOARD_SUFFIX, TASK_SUFFIX)
 			}
 			return nil
 		}
@@ -405,9 +424,9 @@ func isAnyParentFolderUpdated(path string, folderUpdatedAt map[string]time.Time,
 	return false
 }
 
-func getExpectedFilePath(baseDir string, dashboard api.App) (string, error) {
-	// Construct path (same logic as writeDashboardFile)
-	dashPath := dashboard.Path
+func getExpectedFilePath(baseDir string, app api.App) (string, error) {
+	// Construct path (same logic as writeAppFile)
+	dashPath := app.Path
 	if dashPath == "" {
 		dashPath = "/"
 	}
@@ -415,7 +434,11 @@ func getExpectedFilePath(baseDir string, dashboard api.App) (string, error) {
 	dashPath = strings.TrimPrefix(dashPath, "/")
 
 	dirPath := filepath.Join(baseDir, dashPath)
-	fileName := sanitizeFileName(dashboard.Name) + DASHBOARD_SUFFIX
+	suffix := DASHBOARD_SUFFIX
+	if app.Type == "task" {
+		suffix = TASK_SUFFIX
+	}
+	fileName := sanitizeFileName(app.Name) + suffix
 	filePath := filepath.Join(dirPath, fileName)
 
 	// Convert to absolute path for comparison
@@ -426,9 +449,9 @@ func getExpectedFilePath(baseDir string, dashboard api.App) (string, error) {
 	return absPath, nil
 }
 
-func writeDashboardFile(baseDir string, dashboard api.App) error {
+func writeAppFile(baseDir string, app api.App) error {
 	// Construct path
-	dashPath := dashboard.Path
+	dashPath := app.Path
 	if dashPath == "" {
 		dashPath = "/"
 	}
@@ -440,13 +463,17 @@ func writeDashboardFile(baseDir string, dashboard api.App) error {
 		return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
 	}
 
-	fileName := sanitizeFileName(dashboard.Name) + DASHBOARD_SUFFIX
+	suffix := DASHBOARD_SUFFIX
+	if app.Type == "task" {
+		suffix = TASK_SUFFIX
+	}
+	fileName := sanitizeFileName(app.Name) + suffix
 	filePath := filepath.Join(dirPath, fileName)
 
 	// Ensure content has shaper ID
-	content := dashboard.Content
+	content := app.Content
 	if !hasLeadingShaperIDComment(content) {
-		content = prependShaperIDComment(dashboard.ID, content)
+		content = prependShaperIDComment(app.ID, content)
 	}
 
 	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {

--- a/server/dev/pull.go
+++ b/server/dev/pull.go
@@ -24,7 +24,7 @@ func RunPullCommand(ctx context.Context, configPath, authFile string, skipConfir
 		return err
 	}
 
-	watchDir, err := resolveAbsolutePath(cfg.Directory)
+	watchDir, err := resolveConfigDirectory(cfg.Directory, configPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve directory: %w", err)
 	}

--- a/server/dev/watch.go
+++ b/server/dev/watch.go
@@ -26,6 +26,7 @@ const (
 	DASHBOARD_SUFFIX = ".dashboard.sql"
 	TASK_SUFFIX      = ".task.sql"
 	shaperIDPrefix   = "-- shaperid:"
+	shaperSyncPrefix = "-- shapersync:"
 )
 
 type DashboardClient interface {
@@ -425,36 +426,62 @@ func (d *Dev) notifyClients(dashboardID string) bool {
 	}
 	return true
 }
-
-func hasLeadingShaperIDComment(content string) bool {
-	if !strings.HasPrefix(content, shaperIDPrefix) {
-		return false
-	}
-
-	lineEnd := strings.IndexByte(content, '\n')
-	firstLine := content
-	if lineEnd != -1 {
-		firstLine = content[:lineEnd]
-	}
-
-	id := strings.TrimPrefix(firstLine, shaperIDPrefix)
-	if id == "" || strings.ContainsAny(id, " \t\r") {
-		return false
-	}
-
-	return true
+// AppMetadata represents the metadata stored in comments at the top of an app file.
+type AppMetadata struct {
+	ID            string
+	SyncTimestamp *time.Time
 }
 
-func prependShaperIDComment(id, content string) string {
-	commentLine := fmt.Sprintf("%s%s\n", shaperIDPrefix, id)
+// extractAppMetadata reads the leading comments from the file content to extract the Shaper ID and Sync Timestamp.
+func extractAppMetadata(content string) AppMetadata {
+	var meta AppMetadata
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		// Use raw line for prefix matching to catch trailing spaces correctly
+		if strings.HasPrefix(line, shaperIDPrefix) {
+			id := strings.TrimPrefix(line, shaperIDPrefix)
+			if id != "" && !strings.ContainsAny(id, " \t\r") {
+				meta.ID = id
+			}
+		} else if strings.HasPrefix(line, shaperSyncPrefix) {
+			timeStr := strings.TrimSpace(strings.TrimPrefix(line, shaperSyncPrefix))
+			if t, err := time.Parse(time.RFC3339, timeStr); err == nil {
+				meta.SyncTimestamp = &t
+			}
+		} else if strings.TrimSpace(line) != "" {
+			// Stop searching once we hit a non-empty, non-metadata line
+			break
+		}
+	}
+	return meta
+}
+
+func hasLeadingShaperIDComment(content string) bool {
+	meta := extractAppMetadata(content)
+	return meta.ID != ""
+}
+
+func prependAppMetadata(id string, syncTime *time.Time, content string) string {
+	var sb strings.Builder
+	sb.WriteString(shaperIDPrefix)
+	sb.WriteString(id)
+	sb.WriteString("\n")
+
+	if syncTime != nil {
+		sb.WriteString(shaperSyncPrefix)
+		sb.WriteString(syncTime.Format(time.RFC3339))
+		sb.WriteString("\n")
+	}
+
 	if content != "" {
 		if content[0] != '\n' && content[0] != '\r' {
-			commentLine += "\n"
+			sb.WriteString("\n")
 		}
-		commentLine += content
-		return commentLine
+		sb.WriteString(content)
+	} else {
+		sb.WriteString("\n")
 	}
-	return commentLine + "\n"
+	return sb.String()
 }
 
 func ensureShaperIDForFile(filePath string) ([]byte, bool, string, error) {
@@ -464,12 +491,14 @@ func ensureShaperIDForFile(filePath string) ([]byte, bool, string, error) {
 	}
 
 	content := string(contentBytes)
-	if hasLeadingShaperIDComment(content) || strings.TrimSpace(content) == "" {
-		return contentBytes, false, "", nil
+	meta := extractAppMetadata(content)
+	
+	if meta.ID != "" || strings.TrimSpace(content) == "" {
+		return contentBytes, false, meta.ID, nil
 	}
 
 	newID := cuid2.Generate()
-	newContent := prependShaperIDComment(newID, content)
+	newContent := prependAppMetadata(newID, meta.SyncTimestamp, content)
 
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {

--- a/server/dev/watch.go
+++ b/server/dev/watch.go
@@ -129,7 +129,7 @@ Create sub-directories to organize dashboards into folders.`)
 		for ei := range c {
 			p := ei.Path()
 			dev.throttleFileEvent(p, func() {
-				dev.handleDashboardFile(absWatchDir, p)
+				dev.handleAppFile(absWatchDir, p)
 			})
 		}
 	}()
@@ -167,10 +167,13 @@ func (d *Dev) throttleFileEvent(filePath string, handler func()) {
 	handler()
 }
 
-func (d *Dev) handleDashboardFile(absWatchDir, p string) {
-	if !strings.HasSuffix(p, DASHBOARD_SUFFIX) {
-		if strings.HasSuffix(p, ".sql") && !strings.HasSuffix(p, TASK_SUFFIX) {
-			fmt.Printf("WARNING: %s ends with .sql but not with %s; ignoring\n", p, DASHBOARD_SUFFIX)
+func (d *Dev) handleAppFile(absWatchDir, p string) {
+	isDashboard := strings.HasSuffix(p, DASHBOARD_SUFFIX)
+	isTask := strings.HasSuffix(p, TASK_SUFFIX)
+
+	if !isDashboard && !isTask {
+		if strings.HasSuffix(p, ".sql") {
+			fmt.Printf("WARNING: %s ends with .sql but not with %s or %s; ignoring\n", p, DASHBOARD_SUFFIX, TASK_SUFFIX)
 		}
 		return
 	}
@@ -181,9 +184,14 @@ func (d *Dev) handleDashboardFile(absWatchDir, p string) {
 		fmt.Printf("ERROR: Failed removing prefix '%s' from dir %s\n", absWatchDir, path.Dir(p))
 		return
 	}
-	name, found := strings.CutSuffix(path.Base(p), DASHBOARD_SUFFIX)
+
+	suffix := DASHBOARD_SUFFIX
+	if isTask {
+		suffix = TASK_SUFFIX
+	}
+	name, found := strings.CutSuffix(path.Base(p), suffix)
 	if !found {
-		fmt.Printf("ERROR: Failed removing suffix '%s' from file name '%s'\n", DASHBOARD_SUFFIX, path.Base(p))
+		fmt.Printf("ERROR: Failed removing suffix '%s' from file name '%s'\n", suffix, path.Base(p))
 		return
 	}
 
@@ -196,6 +204,11 @@ func (d *Dev) handleDashboardFile(absWatchDir, p string) {
 
 	if updated {
 		fmt.Printf("Set id '%s' for file '%s'\n", shaperID, p)
+	}
+
+	if isTask {
+		// For tasks, we just ensure the ID is generated but do not preview.
+		return
 	}
 
 	content := string(contentBytes)
@@ -481,9 +494,12 @@ func ensureShaperIDsForDir(dir string) (int, error) {
 		if d.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX) {
-			if strings.HasSuffix(d.Name(), ".sql") && !strings.HasSuffix(d.Name(), TASK_SUFFIX) {
-				fmt.Printf("WARNING: %s ends with .sql but not with %s; ignoring\n", p, DASHBOARD_SUFFIX)
+		isDashboard := strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX)
+		isTask := strings.HasSuffix(d.Name(), TASK_SUFFIX)
+
+		if !isDashboard && !isTask {
+			if strings.HasSuffix(d.Name(), ".sql") {
+				fmt.Printf("WARNING: %s ends with .sql but not with %s or %s; ignoring\n", p, DASHBOARD_SUFFIX, TASK_SUFFIX)
 			}
 			return nil
 		}

--- a/server/dev/watch.go
+++ b/server/dev/watch.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	DASHBOARD_SUFFIX = ".dashboard.sql"
+	TASK_SUFFIX      = ".task.sql"
 	shaperIDPrefix   = "-- shaperid:"
 )
 
@@ -168,7 +169,7 @@ func (d *Dev) throttleFileEvent(filePath string, handler func()) {
 
 func (d *Dev) handleDashboardFile(absWatchDir, p string) {
 	if !strings.HasSuffix(p, DASHBOARD_SUFFIX) {
-		if strings.HasSuffix(p, ".sql") {
+		if strings.HasSuffix(p, ".sql") && !strings.HasSuffix(p, TASK_SUFFIX) {
 			fmt.Printf("WARNING: %s ends with .sql but not with %s; ignoring\n", p, DASHBOARD_SUFFIX)
 		}
 		return
@@ -481,7 +482,7 @@ func ensureShaperIDsForDir(dir string) (int, error) {
 			return nil
 		}
 		if !strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX) {
-			if strings.HasSuffix(d.Name(), ".sql") {
+			if strings.HasSuffix(d.Name(), ".sql") && !strings.HasSuffix(d.Name(), TASK_SUFFIX) {
 				fmt.Printf("WARNING: %s ends with .sql but not with %s; ignoring\n", p, DASHBOARD_SUFFIX)
 			}
 			return nil

--- a/server/dev/watch_test.go
+++ b/server/dev/watch_test.go
@@ -51,7 +51,7 @@ func TestHasLeadingShaperIDComment(t *testing.T) {
 	}
 }
 
-func TestPrependShaperIDComment(t *testing.T) {
+func TestPrependAppMetadata(t *testing.T) {
 	tests := []struct {
 		name     string
 		content  string
@@ -76,7 +76,7 @@ func TestPrependShaperIDComment(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := prependShaperIDComment("testid", tc.content)
+			got := prependAppMetadata("testid", nil, tc.content)
 			if got != tc.expected {
 				t.Fatalf("expected %q, got %q", tc.expected, got)
 			}

--- a/server/web/handler/deploy.go
+++ b/server/web/handler/deploy.go
@@ -62,25 +62,26 @@ func Deploy(app *core.App) echo.HandlerFunc {
 }
 
 func processDeployOperation(ctx context.Context, app *core.App, idx int, req api.AppRequest) (deployResult, error) {
-	switch strings.ToLower(strings.TrimSpace(req.Type)) {
-	case "dashboard":
+	appType := strings.ToLower(strings.TrimSpace(req.Type))
+	switch appType {
+	case "dashboard", "task":
 	default:
 		return deployResult{}, fmt.Errorf("apps[%d]: unsupported type %q", idx, req.Type)
 	}
 
 	switch strings.ToLower(strings.TrimSpace(req.Operation)) {
 	case "create":
-		return handleDeployCreate(ctx, app, idx, req.Data)
+		return handleDeployCreate(ctx, app, idx, req.Data, appType)
 	case "update":
-		return handleDeployUpdate(ctx, app, idx, req.Data)
+		return handleDeployUpdate(ctx, app, idx, req.Data, appType)
 	case "delete":
-		return handleDeployDelete(ctx, app, idx, req.Data)
+		return handleDeployDelete(ctx, app, idx, req.Data, appType)
 	default:
 		return deployResult{}, fmt.Errorf("apps[%d]: unsupported operation %q", idx, req.Operation)
 	}
 }
 
-func handleDeployCreate(ctx context.Context, app *core.App, idx int, data api.DashboardData) (deployResult, error) {
+func handleDeployCreate(ctx context.Context, app *core.App, idx int, data api.DashboardData, appType string) (deployResult, error) {
 	if data.Name == nil || strings.TrimSpace(*data.Name) == "" {
 		return deployResult{}, fmt.Errorf("apps[%d]: name is required for create operations", idx)
 	}
@@ -106,20 +107,25 @@ func handleDeployCreate(ctx context.Context, app *core.App, idx int, data api.Da
 		}
 	}
 
-	id, err := core.CreateDashboard(app, ctx, name, content, path, false, requestedID)
+	var id string
+	if appType == "task" {
+		id, err = core.CreateTask(app, ctx, name, content, path, requestedID)
+	} else {
+		id, err = core.CreateDashboard(app, ctx, name, content, path, false, requestedID)
+	}
 	if err != nil {
 		return deployResult{}, fmt.Errorf("apps[%d]: %w", idx, err)
 	}
 
 	return deployResult{
 		Operation: "create",
-		Type:      "dashboard",
+		Type:      appType,
 		ID:        id,
 		Status:    "created",
 	}, nil
 }
 
-func handleDeployUpdate(ctx context.Context, app *core.App, idx int, data api.DashboardData) (deployResult, error) {
+func handleDeployUpdate(ctx context.Context, app *core.App, idx int, data api.DashboardData, appType string) (deployResult, error) {
 	if data.ID == nil || strings.TrimSpace(*data.ID) == "" {
 		return deployResult{}, fmt.Errorf("apps[%d]: id is required for update operations", idx)
 	}
@@ -132,32 +138,50 @@ func handleDeployUpdate(ctx context.Context, app *core.App, idx int, data api.Da
 		if name == "" {
 			return deployResult{}, fmt.Errorf("apps[%d]: name cannot be empty when provided", idx)
 		}
-		if err := core.SaveDashboardName(app, ctx, id, name); err != nil {
+		var err error
+		if appType == "task" {
+			err = core.SaveTaskName(app, ctx, id, name)
+		} else {
+			err = core.SaveDashboardName(app, ctx, id, name)
+		}
+		if err != nil {
 			return deployResult{}, fmt.Errorf("apps[%d]: %w", idx, err)
 		}
 		changed = true
 	}
 
 	if data.Content != nil {
-		if err := core.SaveDashboardQuery(app, ctx, id, *data.Content); err != nil {
+		var err error
+		if appType == "task" {
+			err = core.SaveTaskContent(app, ctx, id, *data.Content)
+		} else {
+			err = core.SaveDashboardQuery(app, ctx, id, *data.Content)
+		}
+		if err != nil {
 			return deployResult{}, fmt.Errorf("apps[%d]: %w", idx, err)
 		}
 		changed = true
 	}
 
-	var dashboardInfo core.Dashboard
-	var haveDashboardInfo bool
-	getDashboard := func() (core.Dashboard, error) {
-		if haveDashboardInfo {
-			return dashboardInfo, nil
+	var appInfo core.Dashboard // using Dashboard struct to reuse existing path handling logic
+	var haveAppInfo bool
+	getAppInfo := func() (core.Dashboard, error) {
+		if haveAppInfo {
+			return appInfo, nil
 		}
-		info, err := core.GetDashboardInfo(app, ctx, id)
+		var err error
+		if appType == "task" {
+			var task core.Task
+			task, err = core.GetTask(app, ctx, id)
+			appInfo.Path = task.Path
+		} else {
+			appInfo, err = core.GetDashboardInfo(app, ctx, id)
+		}
 		if err != nil {
 			return core.Dashboard{}, err
 		}
-		dashboardInfo = info
-		haveDashboardInfo = true
-		return dashboardInfo, nil
+		haveAppInfo = true
+		return appInfo, nil
 	}
 
 	if data.Path != nil {
@@ -165,17 +189,19 @@ func handleDeployUpdate(ctx context.Context, app *core.App, idx int, data api.Da
 		if err != nil {
 			return deployResult{}, fmt.Errorf("apps[%d]: %w", idx, err)
 		}
-		info, err := getDashboard()
+		info, err := getAppInfo()
 		if err != nil {
 			return deployResult{}, fmt.Errorf("apps[%d]: %w", idx, err)
 		}
 		currentPath := normalizeFolderPath(info.Path)
 		if desiredPath != currentPath {
+			var err error
 			moveReq := core.MoveItemsRequest{
 				Apps: []string{id},
 				Path: desiredPath,
 			}
-			if err := core.MoveItems(app, ctx, moveReq); err != nil {
+			err = core.MoveItems(app, ctx, moveReq)
+			if err != nil {
 				return deployResult{}, fmt.Errorf("apps[%d]: %w", idx, err)
 			}
 			changed = true
@@ -188,25 +214,31 @@ func handleDeployUpdate(ctx context.Context, app *core.App, idx int, data api.Da
 
 	return deployResult{
 		Operation: "update",
-		Type:      "dashboard",
+		Type:      appType,
 		ID:        id,
 		Status:    "updated",
 	}, nil
 }
 
-func handleDeployDelete(ctx context.Context, app *core.App, idx int, data api.DashboardData) (deployResult, error) {
+func handleDeployDelete(ctx context.Context, app *core.App, idx int, data api.DashboardData, appType string) (deployResult, error) {
 	if data.ID == nil || strings.TrimSpace(*data.ID) == "" {
 		return deployResult{}, fmt.Errorf("apps[%d]: id is required for delete operations", idx)
 	}
 
 	id := strings.TrimSpace(*data.ID)
-	if err := core.DeleteDashboard(app, ctx, id); err != nil {
+	var err error
+	if appType == "task" {
+		err = core.DeleteTask(app, ctx, id)
+	} else {
+		err = core.DeleteDashboard(app, ctx, id)
+	}
+	if err != nil {
 		return deployResult{}, fmt.Errorf("apps[%d]: %w", idx, err)
 	}
 
 	return deployResult{
 		Operation: "delete",
-		Type:      "dashboard",
+		Type:      appType,
 		ID:        id,
 		Status:    "deleted",
 	}, nil

--- a/server/web/handler/folders.go
+++ b/server/web/handler/folders.go
@@ -14,6 +14,12 @@ import (
 
 func CreateFolder(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		if app.NoEdit {
+			return c.JSONPretty(http.StatusForbidden, struct {
+				Error string `json:"error"`
+			}{Error: "Editing is disabled"}, "  ")
+		}
+
 		claims := c.Get("user").(*jwt.Token).Claims.(jwt.MapClaims)
 		if _, hasId := claims["dashboardId"]; hasId {
 			return c.JSONPretty(http.StatusUnauthorized, struct {
@@ -63,6 +69,12 @@ func CreateFolder(app *core.App) echo.HandlerFunc {
 
 func DeleteFolder(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		if app.NoEdit {
+			return c.JSONPretty(http.StatusForbidden, struct {
+				Error string `json:"error"`
+			}{Error: "Editing is disabled"}, "  ")
+		}
+
 		claims := c.Get("user").(*jwt.Token).Claims.(jwt.MapClaims)
 		if _, hasId := claims["dashboardId"]; hasId {
 			return c.JSONPretty(http.StatusUnauthorized, struct {
@@ -93,6 +105,12 @@ func DeleteFolder(app *core.App) echo.HandlerFunc {
 
 func MoveItems(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		if app.NoEdit {
+			return c.JSONPretty(http.StatusForbidden, struct {
+				Error string `json:"error"`
+			}{Error: "Editing is disabled"}, "  ")
+		}
+
 		claims := c.Get("user").(*jwt.Token).Claims.(jwt.MapClaims)
 		if _, hasId := claims["dashboardId"]; hasId {
 			return c.JSONPretty(http.StatusUnauthorized, struct {
@@ -137,6 +155,12 @@ func MoveItems(app *core.App) echo.HandlerFunc {
 
 func RenameFolder(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		if app.NoEdit {
+			return c.JSONPretty(http.StatusForbidden, struct {
+				Error string `json:"error"`
+			}{Error: "Editing is disabled"}, "  ")
+		}
+
 		claims := c.Get("user").(*jwt.Token).Claims.(jwt.MapClaims)
 		if _, hasId := claims["dashboardId"]; hasId {
 			return c.JSONPretty(http.StatusUnauthorized, struct {

--- a/server/web/handler/task.go
+++ b/server/web/handler/task.go
@@ -62,6 +62,12 @@ func GetTask(app *core.App) echo.HandlerFunc {
 
 func CreateTask(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		if app.NoEdit {
+			return c.JSONPretty(http.StatusForbidden, struct {
+				Error string `json:"error"`
+			}{Error: "Editing is disabled"}, "  ")
+		}
+
 		claims := c.Get("user").(*jwt.Token).Claims.(jwt.MapClaims)
 		if _, hasId := claims["dashboardId"]; hasId {
 			return c.JSONPretty(http.StatusUnauthorized,
@@ -117,6 +123,12 @@ func CreateTask(app *core.App) echo.HandlerFunc {
 
 func SaveTaskContent(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		if app.NoEdit {
+			return c.JSONPretty(http.StatusForbidden, struct {
+				Error string `json:"error"`
+			}{Error: "Editing is disabled"}, "  ")
+		}
+
 		claims := c.Get("user").(*jwt.Token).Claims.(jwt.MapClaims)
 		if _, hasId := claims["dashboardId"]; hasId {
 			return c.JSONPretty(http.StatusUnauthorized, struct {
@@ -144,6 +156,12 @@ func SaveTaskContent(app *core.App) echo.HandlerFunc {
 
 func SaveTaskName(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		if app.NoEdit {
+			return c.JSONPretty(http.StatusForbidden, struct {
+				Error string `json:"error"`
+			}{Error: "Editing is disabled"}, "  ")
+		}
+
 		claims := c.Get("user").(*jwt.Token).Claims.(jwt.MapClaims)
 		if _, hasId := claims["dashboardId"]; hasId {
 			return c.JSONPretty(http.StatusUnauthorized, struct {
@@ -176,6 +194,12 @@ func SaveTaskName(app *core.App) echo.HandlerFunc {
 
 func DeleteTask(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		if app.NoEdit {
+			return c.JSONPretty(http.StatusForbidden, struct {
+				Error string `json:"error"`
+			}{Error: "Editing is disabled"}, "  ")
+		}
+
 		claims := c.Get("user").(*jwt.Token).Claims.(jwt.MapClaims)
 		if _, hasId := claims["dashboardId"]; hasId {
 			return c.JSONPretty(http.StatusUnauthorized,

--- a/server/web/handler/task.go
+++ b/server/web/handler/task.go
@@ -98,7 +98,7 @@ func CreateTask(app *core.App) echo.HandlerFunc {
 				}{Error: err.Error()}, "  ")
 		}
 
-		id, err := core.CreateTask(app, c.Request().Context(), request.Name, request.Content, request.Path)
+		id, err := core.CreateTask(app, c.Request().Context(), request.Name, request.Content, request.Path, "")
 		if err != nil {
 			c.Logger().Error("error creating task:", slog.Any("error", err))
 			return c.JSONPretty(http.StatusBadRequest,

--- a/ui/src/components/SqlEditor.tsx
+++ b/ui/src/components/SqlEditor.tsx
@@ -9,10 +9,12 @@ export function SqlEditor ({
   onChange,
   onRun,
   content,
+  readOnly,
 }: {
   onChange: (value: string | undefined) => void;
   onRun: () => void;
   content: string;
+  readOnly?: boolean;
 }) {
   const { isDarkMode } = useContext(DarkModeContext);
 
@@ -46,6 +48,7 @@ export function SqlEditor ({
       theme={isDarkMode ? "vs-dark" : "light"}
       options={{
         minimap: { enabled: false },
+        readOnly: readOnly,
         fontSize: 14,
         lineNumbers: "on",
         scrollBeyondLastLine: true,

--- a/ui/src/components/providers/MenuProvider.tsx
+++ b/ui/src/components/providers/MenuProvider.tsx
@@ -180,7 +180,7 @@ export function MenuProvider ({
               Browse
             </Tooltip>
           </Link>
-          {(config.editEnabled || config.tasksEnabled) && (
+          {config.editEnabled && (
             <Link
               to="/new"
               search={{ path: currentPath }}
@@ -191,11 +191,7 @@ export function MenuProvider ({
               })}
             >
               <RiFileAddLine className="size-4 inline mr-1.5 mb-1" />
-              {config.tasksEnabled
-                ? config.editEnabled
-                  ? "New"
-                  : "New Task"
-                : "New Dashboard"}
+              {config.tasksEnabled ? "New" : "New Dashboard"}
             </Link>
           )}
           {extraContent}

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -945,7 +945,7 @@ function Index () {
                                 <RiPencilLine className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 hover:fill-cprimary dark:hover:fill-dprimary transition-colors duration-200" />
                               </Tooltip>
                             </button>
-                          ) : (!(app.type === "dashboard" && !getSystemConfig().editEnabled) && (
+                          ) : (getSystemConfig().editEnabled && (
                             <Link
                               to={
                                 app.type === "dashboard"
@@ -963,7 +963,7 @@ function Index () {
                               </Tooltip>
                             </Link>
                           ))}
-                          {!(app.type === "dashboard" && !getSystemConfig().editEnabled) && (
+                          {getSystemConfig().editEnabled && (
                             <button
                               onClick={() => {
                                 setDeleteDialog(app);

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -596,10 +596,10 @@ function Index () {
                         "bg-cbga dark:bg-dbga": draggedItem != null && draggedItem.path !== breadcrumb.path,
                       },
                     )}
-                    onDragOver={(e) => handleDragOver(e, breadcrumb.path)}
+                    onDragOver={(e) => getSystemConfig().editEnabled && handleDragOver(e, breadcrumb.path)}
                     onDragLeave={handleDragLeave}
-                    onDrop={(e) => handleDrop(e, breadcrumb.path)}
-                    onTouchMove={(e) => handleTouchMove(e, breadcrumb.path)}
+                    onDrop={(e) => getSystemConfig().editEnabled && handleDrop(e, breadcrumb.path)}
+                    onTouchMove={(e) => getSystemConfig().editEnabled && handleTouchMove(e, breadcrumb.path)}
                     data-drop-target
                     data-target-path={breadcrumb.path}
                   >
@@ -609,20 +609,22 @@ function Index () {
               ))}
             </nav>
           </div>
-          <div className="flex">
-            <Tooltip showArrow={false} content="New Folder">
-              <Button
-                variant="secondary"
-                className="py-2 px-2.5"
-                onClick={() => setFolderDialog(true)}
-              >
-                <RiFolderAddLine
-                  className="size-4 shrink-0"
-                  aria-hidden={true}
-                />
-              </Button>
-            </Tooltip>
-          </div>
+          {getSystemConfig().editEnabled && (
+            <div className="flex">
+              <Tooltip showArrow={false} content="New Folder">
+                <Button
+                  variant="secondary"
+                  className="py-2 px-2.5"
+                  onClick={() => setFolderDialog(true)}
+                >
+                  <RiFolderAddLine
+                    className="size-4 shrink-0"
+                    aria-hidden={true}
+                  />
+                </Button>
+              </Tooltip>
+            </div>
+          )}
         </div>
 
         <div className="bg-cbgs dark:bg-dbgs rounded-md shadow flex-grow md:mt-2 md:mx-3 md:p-3 h-[calc(100%-4rem)]">
@@ -691,20 +693,20 @@ function Index () {
                           "bg-cbga dark:bg-dbga [tbody_&]:odd:bg-cbga [tbody_&]:odd:dark:bg-dbga": draggedItem != null && app.type === "_folder" && draggedItem.id !== app.id,
                         },
                       )}
-                      draggable
-                      onDragStart={(e) => handleDragStart(e, app)}
+                      draggable={getSystemConfig().editEnabled}
+                      onDragStart={(e) => getSystemConfig().editEnabled && handleDragStart(e, app)}
                       onDragEnd={handleDragEnd}
-                      onTouchStart={(e) => handleTouchStart(e, app)}
+                      onTouchStart={(e) => getSystemConfig().editEnabled && handleTouchStart(e, app)}
                       onTouchEnd={handleTouchEnd}
                       {...(app.type === "_folder"
                         ? {
                           onDragOver: (e: React.DragEvent) =>
-                            handleDragOver(e, app.path + app.name + "/", app),
+                            getSystemConfig().editEnabled && handleDragOver(e, app.path + app.name + "/", app),
                           onDragLeave: handleDragLeave,
                           onDrop: (e: React.DragEvent) =>
-                            handleDrop(e, app.path + app.name + "/", app),
+                            getSystemConfig().editEnabled && handleDrop(e, app.path + app.name + "/", app),
                           onTouchMove: (e: React.TouchEvent) =>
-                            handleTouchMove(e, app.path + app.name + "/"),
+                            getSystemConfig().editEnabled && handleTouchMove(e, app.path + app.name + "/"),
                           "data-drop-target": true,
                           "data-target-path": app.path + app.name + "/",
                         }
@@ -934,48 +936,50 @@ function Index () {
                       </TableCell>
                       <TableCell className="text-right">
                         <div className="flex gap-4 justify-end">
-                          {app.type === "_folder" ? (
-                            <button
-                              onClick={() => {
-                                setRenameDialog(app);
-                                setRenameName(app.name);
-                              }}
-                            >
-                              <Tooltip showArrow={false} content="Rename">
-                                <RiPencilLine className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 hover:fill-cprimary dark:hover:fill-dprimary transition-colors duration-200" />
-                              </Tooltip>
-                            </button>
-                          ) : (getSystemConfig().editEnabled && (
-                            <Link
-                              to={
-                                app.type === "dashboard"
-                                  ? "/dashboards/$id/edit"
-                                  : "/tasks/$id"
-                              }
-                              params={{ id: app.id }}
-                              className={cx(
-                                "text-ctext2 dark:text-dtext2 hover:text-ctext dark:hover:text-dtext",
-                                "hover:underline transition-colors duration-200",
-                              )}
-                            >
-                              <Tooltip showArrow={false} content="Edit">
-                                <RiPencilLine className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 hover:fill-cprimary dark:hover:fill-dprimary transition-colors duration-200" />
-                              </Tooltip>
-                            </Link>
-                          ))}
                           {getSystemConfig().editEnabled && (
-                            <button
-                              onClick={() => {
-                                setDeleteDialog(app);
-                              }}
-                            >
-                              <Tooltip showArrow={false} content="Delete">
-                                <RiDeleteBinLine
-                                  className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 hover:fill-cerr dark:hover:fill-derr transition-colors duration-200"
-                                  aria-hidden={true}
-                                />
-                              </Tooltip>
-                            </button>
+                            <>
+                              {app.type === "_folder" ? (
+                                <button
+                                  onClick={() => {
+                                    setRenameDialog(app);
+                                    setRenameName(app.name);
+                                  }}
+                                >
+                                  <Tooltip showArrow={false} content="Rename">
+                                    <RiPencilLine className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 hover:fill-cprimary dark:hover:fill-dprimary transition-colors duration-200" />
+                                  </Tooltip>
+                                </button>
+                              ) : (
+                                <Link
+                                  to={
+                                    app.type === "dashboard"
+                                      ? "/dashboards/$id/edit"
+                                      : "/tasks/$id"
+                                  }
+                                  params={{ id: app.id }}
+                                  className={cx(
+                                    "text-ctext2 dark:text-dtext2 hover:text-ctext dark:hover:text-dtext",
+                                    "hover:underline transition-colors duration-200",
+                                  )}
+                                >
+                                  <Tooltip showArrow={false} content="Edit">
+                                    <RiPencilLine className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 hover:fill-cprimary dark:hover:fill-dprimary transition-colors duration-200" />
+                                  </Tooltip>
+                                </Link>
+                              )}
+                              <button
+                                onClick={() => {
+                                  setDeleteDialog(app);
+                                }}
+                              >
+                                <Tooltip showArrow={false} content="Delete">
+                                  <RiDeleteBinLine
+                                    className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 hover:fill-cerr dark:hover:fill-derr transition-colors duration-200"
+                                    aria-hidden={true}
+                                  />
+                                </Tooltip>
+                              </button>
+                            </>
                           )}
                         </div>
                       </TableCell>

--- a/ui/src/routes/new.tsx
+++ b/ui/src/routes/new.tsx
@@ -112,7 +112,7 @@ export const Route = createFileRoute("/new")({
   }),
   beforeLoad: () => {
     const systemConfig = getSystemConfig();
-    if (!systemConfig.editEnabled && !systemConfig.tasksEnabled) {
+    if (!systemConfig.editEnabled) {
       throw redirect({ to: "/" });
     }
   },
@@ -126,7 +126,7 @@ function NewDashboard () {
   const navigate = useNavigate({ from: "/new" });
   const systemConfig = getSystemConfig();
   const [appType, setAppType] = useState<"dashboard" | "task">(() =>
-    systemConfig.editEnabled ? getStoredAppType() : "task",
+    systemConfig.tasksEnabled ? getStoredAppType() : "dashboard",
   );
   const [editorQuery, setEditorQuery] = useState("");
   const [runningQuery, setRunningQuery] = useState("");

--- a/ui/src/routes/tasks.$id.tsx
+++ b/ui/src/routes/tasks.$id.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-import { createFileRoute, isRedirect, useNavigate, useRouter } from "@tanstack/react-router";
+import { createFileRoute, isRedirect, redirect, useNavigate, useRouter } from "@tanstack/react-router";
 import { useCallback, useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { RiPencilLine, RiCloseLine } from "@remixicon/react";
@@ -44,6 +44,12 @@ interface TaskData {
 }
 
 export const Route = createFileRoute("/tasks/$id")({
+  beforeLoad: () => {
+    const systemConfig = getSystemConfig();
+    if (!systemConfig.tasksEnabled) {
+      throw redirect({ to: "/" });
+    }
+  },
   loader: async ({ context: { queryApi }, params: { id } }) => {
     return queryApi(`tasks/${id}`) as Promise<TaskData>;
   },

--- a/ui/src/routes/tasks.$id.tsx
+++ b/ui/src/routes/tasks.$id.tsx
@@ -28,6 +28,7 @@ import { SqlEditor } from "../components/SqlEditor";
 import { PreviewError } from "../components/PreviewError";
 import { TaskResults, TaskResult } from "../components/TaskResults";
 import { RelativeDate } from "../components/RelativeDate";
+import { getSystemConfig } from "../lib/system";
 import "../lib/editorInit";
 
 interface TaskData {
@@ -50,6 +51,7 @@ export const Route = createFileRoute("/tasks/$id")({
 });
 
 function TaskEdit () {
+  const systemConfig = getSystemConfig();
   const { id } = Route.useParams();
   const task = Route.useLoaderData();
   const queryApi = useQueryApi();
@@ -242,17 +244,19 @@ function TaskEdit () {
                     </div>
                   </div>
                 )}
-                <Button
-                  onClick={() => setShowDeleteDialog(true)}
-                  variant='destructive'
-                  className='mt-4'
-                >
-                  Delete Task
-                </Button>
+                {systemConfig.editEnabled && (
+                  <Button
+                    onClick={() => setShowDeleteDialog(true)}
+                    variant='destructive'
+                    className='mt-4'
+                  >
+                    Delete Task
+                  </Button>
+                )}
               </div>
             </MenuTrigger>
 
-            {editingName ? (
+            {systemConfig.editEnabled && editingName ? (
               <form
                 onSubmit={(e) => {
                   e.preventDefault();
@@ -299,52 +303,62 @@ function TaskEdit () {
               </form>
             ) : (
               <div className="hidden sm:block flex-grow">
-                <Tooltip
-                  showArrow={false}
-                  asChild
-                  content="Click to edit task name"
-                >
-                  <h1
-                    className="text-xl font-semibold font-display cursor-pointer hover:bg-cbga dark:hover:bg-dbga px-2 py-0.5 rounded inline-block"
-                    onClick={() => setEditingName(true)}
+                {systemConfig.editEnabled ? (
+                  <Tooltip
+                    showArrow={false}
+                    asChild
+                    content="Click to edit task name"
                   >
+                    <h1
+                      className="text-xl font-semibold font-display cursor-pointer hover:bg-cbga dark:hover:bg-dbga px-2 py-0.5 rounded inline-block"
+                      onClick={() => setEditingName(true)}
+                    >
+                      {name}
+                      <RiPencilLine className="size-4 inline ml-1.5 mb-1" />
+                    </h1>
+                  </Tooltip>
+                ) : (
+                  <h1 className="text-xl font-semibold font-display px-2 py-0.5 inline-block">
                     {name}
-                    <RiPencilLine className="size-4 inline ml-1.5 mb-1" />
                   </h1>
-                </Tooltip>
+                )}
               </div>
             )}
 
             <div className="space-x-2">
-              <Tooltip
-                showArrow={false}
-                asChild
-                content='Discard Changes'
-              >
-                <Button
-                  onClick={() => setShowDiscardDialog(true)}
-                  className={cx("ml-2", { "hidden": editorQuery === task?.content })}
-                  disabled={editorQuery === task?.content}
-                  variant='destructive'
-                >
-                  Discard
-                </Button>
-              </Tooltip>
-              <Tooltip
-                showArrow={false}
-                asChild
-                content='Save Task'
-              >
-                <Button
-                  onClick={handleSave}
-                  className={cx("ml-2", { "hidden": editorQuery === task?.content })}
-                  disabled={saving || editorQuery === task?.content}
-                  isLoading={saving}
-                  variant='secondary'
-                >
-                  Save
-                </Button>
-              </Tooltip>
+              {systemConfig.editEnabled && (
+                <>
+                  <Tooltip
+                    showArrow={false}
+                    asChild
+                    content='Discard Changes'
+                  >
+                    <Button
+                      onClick={() => setShowDiscardDialog(true)}
+                      className={cx("ml-2", { "hidden": editorQuery === task?.content })}
+                      disabled={editorQuery === task?.content}
+                      variant='destructive'
+                    >
+                      Discard
+                    </Button>
+                  </Tooltip>
+                  <Tooltip
+                    showArrow={false}
+                    asChild
+                    content='Save Task'
+                  >
+                    <Button
+                      onClick={handleSave}
+                      className={cx("ml-2", { "hidden": editorQuery === task?.content })}
+                      disabled={saving || editorQuery === task?.content}
+                      isLoading={saving}
+                      variant='secondary'
+                    >
+                      Save
+                    </Button>
+                  </Tooltip>
+                </>
+              )}
               <Tooltip
                 showArrow={false}
                 asChild
@@ -366,6 +380,7 @@ function TaskEdit () {
               onChange={handleQueryChange}
               onRun={handleRun}
               content={editorQuery}
+              readOnly={!systemConfig.editEnabled}
             />
           </div>
         </div>


### PR DESCRIPTION
Tasks are now also managed as files with the local `pull/deploy/dev/ids` commands.

Task files end with `.task.sql`.

The commands essentially work the same for tasks as they do for dashboards. Only `dev` behaves differently. For tasks there is no preview. The never run automatically. Only once you deploy them they are running. So for tasks the `dev` commands only handles the creation of the `shaperid` comments (what the `ids` command also does).

This closes the issue for "analytics as code". Closes #22. 

---

The PR introduces a fix that now the `directory` in the `shaper.json` file is relative to the config file location and not relative to the current working directory. That's how I expect it to behave.

---

Might not have been the best idea to put this in here, but the PR also changes how we track remote changes:
Before we had a field `lastPull` in the config file that changed every time a file changed.
Now we track a timestamp in each file as shapersync comment instead.
This avoids unnecessary merge conflicts when users edited different files, it makes it easy to pick the latest file when resolving conflicts 

---

The `--no-edit` flag now also disables tasks in the UI. Closes #148.