### PR TITLE
`validate` and `preview` commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      # this permission is mandatory for Trusted Publishing
       id-token: write
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -347,6 +348,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      # this permission is mandatory for Trusted Publishing
       id-token: write
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -424,8 +426,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1.12.4
+        # No token needed since we are using Trusted Publishing
         with:
           packages-dir: pip-package/dist/
-          # No token needed if Trusted Publishing is set up.
-          # Fallback to token if secret is provided.
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -253,6 +253,7 @@ func buildRootCommand(ctx context.Context) *ff.Command {
 	var subcommands []*ff.Command
 	subcommands = append(subcommands,
 		addDevSubcommand(rootCmd),
+		addPreviewSubcommand(rootCmd),
 		addPullSubcommand(rootCmd),
 		addIdsSubcommand(rootCmd),
 		addDeploySubcommand(rootCmd),
@@ -438,6 +439,34 @@ func addDevSubcommand(rootCmd *ff.Command) *ff.Command {
 	}
 	rootCmd.Subcommands = append(rootCmd.Subcommands, devCmd)
 	return devCmd
+}
+
+func addPreviewSubcommand(rootCmd *ff.Command) *ff.Command {
+	previewFlags := ff.NewFlagSet("preview")
+	help := previewFlags.Bool('h', "help", "show help")
+	previewConfigPath := previewFlags.StringLong("config", "./shaper.json", "Path to config file")
+	previewAuthFile := previewFlags.StringLong("auth-file", ".shaper-auth", "Path to auth token file")
+	noOpen := previewFlags.BoolLong("no-open", "Disable auto-opening the dashboard in the browser")
+
+	usage := "create a temporary dashboard preview"
+	previewCmd := &ff.Command{
+		Name:      "preview",
+		Usage:     "shaper preview <path/to/dashboard.dashboard.sql> [--config path] [--auth-file path] [--no-open]",
+		ShortHelp: usage,
+		Flags:     previewFlags,
+		Exec: func(ctx context.Context, args []string) error {
+			if *help {
+				fmt.Printf("%s\n", ffhelp.Flags(previewFlags, usage))
+				return nil
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("preview requires exactly one dashboard file path")
+			}
+			return dev.RunPreviewCommand(ctx, *previewConfigPath, *previewAuthFile, *noOpen, args[0])
+		},
+	}
+	rootCmd.Subcommands = append(rootCmd.Subcommands, previewCmd)
+	return previewCmd
 }
 
 func addPullSubcommand(rootCmd *ff.Command) *ff.Command {

--- a/main.go
+++ b/main.go
@@ -256,6 +256,7 @@ func buildRootCommand(ctx context.Context) *ff.Command {
 		addPullSubcommand(rootCmd),
 		addIdsSubcommand(rootCmd),
 		addDeploySubcommand(rootCmd),
+		addValidateSubcommand(rootCmd),
 	)
 
 	// Set up the root command execution
@@ -511,6 +512,35 @@ func addDeploySubcommand(rootCmd *ff.Command) *ff.Command {
 	}
 	rootCmd.Subcommands = append(rootCmd.Subcommands, deployCmd)
 	return deployCmd
+}
+
+func addValidateSubcommand(rootCmd *ff.Command) *ff.Command {
+	validateFlags := ff.NewFlagSet("validate")
+	help := validateFlags.Bool('h', "help", "show help")
+	validateConfigPath := validateFlags.StringLong("config", "./shaper.json", "Path to config file")
+
+	usage := `Validate dashboards and tasks.
+  
+  If no files are passed, all dashboards in the configured directory are validated.
+  Otherwise, pass file paths to .dashboard.sql files or folders.
+  
+  Set SHAPER_DEPLOY_API_KEY to authenticate.`
+
+	validateCmd := &ff.Command{
+		Name:      "validate",
+		Usage:     "shaper validate [files...] [--config path]",
+		ShortHelp: "Validate dashboards",
+		Flags:     validateFlags,
+		Exec: func(ctx context.Context, args []string) error {
+			if *help {
+				fmt.Printf("%s\n", ffhelp.Flags(validateFlags, usage))
+				return nil
+			}
+			return dev.RunValidateCommand(ctx, *validateConfigPath, args)
+		},
+	}
+	rootCmd.Subcommands = append(rootCmd.Subcommands, validateCmd)
+	return validateCmd
 }
 
 func Run(cfg Config) func(context.Context) {

--- a/server/dev/preview.go
+++ b/server/dev/preview.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package dev
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func RunPreviewCommand(ctx context.Context, configPath, authFile string, noOpen bool, dashboardPath string) error {
+	if !strings.HasSuffix(dashboardPath, DASHBOARD_SUFFIX) {
+		return fmt.Errorf("file %s is not a dashboard (must end with %s)", dashboardPath, DASHBOARD_SUFFIX)
+	}
+
+	cfg, err := loadOrPromptConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	if authFile == "" {
+		authFile = defaultAuthFile
+	}
+	authFilePath, err := resolveAbsolutePath(authFile)
+	if err != nil {
+		return fmt.Errorf("failed to resolve auth file path: %w", err)
+	}
+
+	systemCfg, err := fetchSystemConfig(ctx, cfg.URL)
+	if err != nil {
+		return err
+	}
+
+	authManager := NewAuthManager(ctx, cfg.URL, authFilePath, systemCfg.LoginRequired)
+	if err := authManager.EnsureSession(); err != nil {
+		return err
+	}
+
+	client, err := NewAPIClient(ctx, cfg.URL, authManager)
+	if err != nil {
+		return fmt.Errorf("failed to initialize API client: %w", err)
+	}
+
+	content, err := os.ReadFile(dashboardPath)
+	if err != nil {
+		return fmt.Errorf("failed to read dashboard file: %w", err)
+	}
+
+	name := strings.TrimSuffix(filepath.Base(dashboardPath), DASHBOARD_SUFFIX)
+
+	dashboardID, err := client.CreateDashboard(ctx, name, string(content), "/")
+	if err != nil {
+		return fmt.Errorf("failed to create preview dashboard: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/dashboards/%s", strings.TrimSuffix(cfg.URL, "/"), dashboardID)
+	fmt.Printf("Preview created: %s\n", url)
+
+	if !noOpen {
+		fmt.Printf("Opening %s in browser...\n", url)
+		if err := OpenURL(url); err != nil {
+			fmt.Printf("WARNING: Failed to open browser: %v\n", err)
+		}
+	}
+
+	return nil
+}

--- a/server/dev/validate.go
+++ b/server/dev/validate.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ValidateResponse struct {
+	Valid    bool   `json:"valid"`
+	Duration int64  `json:"duration"`
+	Error    string `json:"error,omitempty"`
+}
+
+func RunValidateCommand(ctx context.Context, configPath string, args []string) error {
+	cfg, err := loadOrPromptConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	systemCfg, err := fetchSystemConfig(ctx, cfg.URL)
+	if err != nil {
+		return err
+	}
+
+	apiKey := strings.TrimSpace(os.Getenv(deployAPIKeyEnv))
+
+	var client appsRequester
+	if apiKey != "" {
+		client, err = newAPIKeyClient(cfg.URL, apiKey)
+		if err != nil {
+			return err
+		}
+	} else if systemCfg.LoginRequired {
+		authFilePath, err := resolveAbsolutePath(defaultAuthFile)
+		if err != nil {
+			return err
+		}
+		authManager := NewAuthManager(ctx, cfg.URL, authFilePath, systemCfg.LoginRequired)
+		if err := authManager.EnsureSession(); err != nil {
+			return err
+		}
+		client, err = NewAPIClient(ctx, cfg.URL, authManager)
+		if err != nil {
+			return err
+		}
+	} else {
+		client = newOpenDeployClient(cfg.URL)
+	}
+
+	// Figure out files to validate
+	var filesToValidate []string
+	if len(args) == 0 {
+		// Scan directory
+		watchDir, err := resolveConfigDirectory(cfg.Directory, configPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve directory: %w", err)
+		}
+		if err := ensureDirExists(watchDir); err != nil {
+			return err
+		}
+
+		err = filepath.WalkDir(watchDir, func(p string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			isDashboard := strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX)
+			if isDashboard {
+				filesToValidate = append(filesToValidate, p)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		// Walk provided paths
+		for _, arg := range args {
+			stat, err := os.Stat(arg)
+			if err != nil {
+				return fmt.Errorf("invalid path %s: %w", arg, err)
+			}
+			if stat.IsDir() {
+				err = filepath.WalkDir(arg, func(p string, d fs.DirEntry, walkErr error) error {
+					if walkErr != nil {
+						return walkErr
+					}
+					if d.IsDir() {
+						return nil
+					}
+					isDashboard := strings.HasSuffix(d.Name(), DASHBOARD_SUFFIX)
+					if isDashboard {
+						filesToValidate = append(filesToValidate, p)
+					}
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				isDashboard := strings.HasSuffix(stat.Name(), DASHBOARD_SUFFIX)
+				isTask := strings.HasSuffix(stat.Name(), TASK_SUFFIX)
+				if isTask {
+					return fmt.Errorf("task validation is not supported yet: %s", arg)
+				}
+				if !isDashboard {
+					return fmt.Errorf("file %s is not a dashboard (must end with %s)", arg, DASHBOARD_SUFFIX)
+				}
+				filesToValidate = append(filesToValidate, arg)
+			}
+		}
+	}
+
+	if len(filesToValidate) == 0 {
+		fmt.Println("No dashboards found to validate.")
+		return nil
+	}
+
+	fmt.Printf("Validating %d dashboards...\n\n", len(filesToValidate))
+
+	hasErrors := false
+	var errorsCount int
+
+	for _, p := range filesToValidate {
+		contentBytes, err := os.ReadFile(p)
+		if err != nil {
+			fmt.Printf("ERROR reading %s: %v\n", p, err)
+			errorsCount++
+			hasErrors = true
+			continue
+		}
+
+		content := string(contentBytes)
+
+		meta := extractAppMetadata(content)
+		if meta.ID == "" {
+			fmt.Printf("❌ %s\n   Error: missing shaperid comment. Run `shaper ids` to generate IDs for all apps.\n", p)
+			errorsCount++
+			hasErrors = true
+			continue
+		}
+
+		reqBody, err := json.Marshal(map[string]string{
+			"type": "dashboard",
+			"sql":  content,
+		})
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.DoRequest(ctx, http.MethodPost, "/api/validate", reqBody)
+		if err != nil {
+			fmt.Printf("ERROR communicating with server for %s: %v\n", p, err)
+			errorsCount++
+			hasErrors = true
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			fmt.Printf("ERROR from server for %s: status %d\n", p, resp.StatusCode)
+			resp.Body.Close()
+			errorsCount++
+			hasErrors = true
+			continue
+		}
+
+		var valResp ValidateResponse
+		if err := json.NewDecoder(resp.Body).Decode(&valResp); err != nil {
+			fmt.Printf("ERROR decoding response for %s: %v\n", p, err)
+			resp.Body.Close()
+			errorsCount++
+			hasErrors = true
+			continue
+		}
+		resp.Body.Close()
+
+		if valResp.Valid {
+			fmt.Printf("✅ %s (%dms)\n", p, valResp.Duration)
+		} else {
+			fmt.Printf("❌ %s (%dms)\n   Error: %s\n", p, valResp.Duration, valResp.Error)
+			errorsCount++
+			hasErrors = true
+		}
+	}
+
+	if hasErrors {
+		return fmt.Errorf("validation failed for %d dashboard(s)", errorsCount)
+	}
+
+	fmt.Println("\nAll dashboards are valid!")
+	return nil
+}

--- a/server/web/handler/validate.go
+++ b/server/web/handler/validate.go
@@ -7,6 +7,7 @@ import (
 	"shaper/server/core"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 )
 
@@ -23,6 +24,16 @@ type ValidateResponse struct {
 
 func Validate(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		ctxUser := c.Get("user")
+		if ctxUser != nil {
+			claims := ctxUser.(*jwt.Token).Claims.(jwt.MapClaims)
+			if _, hasId := claims["dashboardId"]; hasId {
+				return c.JSONPretty(http.StatusUnauthorized, struct {
+					Error string `json:"error"`
+				}{Error: "Unauthorized"}, "  ")
+			}
+		}
+
 		var req ValidateRequest
 		if err := c.Bind(&req); err != nil {
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})

--- a/server/web/handler/validate.go
+++ b/server/web/handler/validate.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package handler
+
+import (
+	"net/http"
+	"shaper/server/core"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+type ValidateRequest struct {
+	Type string `json:"type"`
+	SQL  string `json:"sql"`
+}
+
+type ValidateResponse struct {
+	Valid    bool   `json:"valid"`
+	Duration int64  `json:"duration"`
+	Error    string `json:"error,omitempty"`
+}
+
+func Validate(app *core.App) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var req ValidateRequest
+		if err := c.Bind(&req); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		}
+
+		if req.Type == "task" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Task validation is currently not supported"})
+		}
+
+		if req.Type != "dashboard" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid type. Must be 'dashboard' or 'task'"})
+		}
+
+		start := time.Now()
+		_, err := core.QueryDashboard(app, c.Request().Context(), core.DashboardQuery{
+			Content: req.SQL,
+			ID:      "validate",
+		}, nil, nil)
+		duration := time.Since(start).Milliseconds()
+
+		if err != nil {
+			return c.JSON(http.StatusOK, ValidateResponse{
+				Valid:    false,
+				Error:    err.Error(),
+				Duration: duration,
+			})
+		}
+
+		return c.JSON(http.StatusOK, ValidateResponse{
+			Valid:    true,
+			Duration: duration,
+		})
+	}
+}

--- a/server/web/handler/validate_test.go
+++ b/server/web/handler/validate_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"shaper/server/core"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/labstack/echo/v4"
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func TestValidate(t *testing.T) {
+	e := echo.New()
+	
+	db, err := sqlx.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("failed to open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	app := &core.App{DuckDB: db}
+	
+	t.Run("valid dashboard", func(t *testing.T) {
+		reqBody, _ := json.Marshal(ValidateRequest{
+			Type: "dashboard",
+			SQL:  "SELECT 1",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/validate", bytes.NewReader(reqBody))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		handler := Validate(app)
+		if err := handler(c); err != nil {
+			t.Fatalf("handler failed: %v", err)
+		}
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		var resp ValidateResponse
+		json.Unmarshal(rec.Body.Bytes(), &resp)
+		if !resp.Valid {
+			t.Errorf("expected valid to be true, got false. Error: %s", resp.Error)
+		}
+	})
+
+	t.Run("invalid dashboard SQL", func(t *testing.T) {
+		reqBody, _ := json.Marshal(ValidateRequest{
+			Type: "dashboard",
+			SQL:  "SELECT * FROM non_existent_table",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/validate", bytes.NewReader(reqBody))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		handler := Validate(app)
+		if err := handler(c); err != nil {
+			t.Fatalf("handler failed: %v", err)
+		}
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		var resp ValidateResponse
+		json.Unmarshal(rec.Body.Bytes(), &resp)
+		if resp.Valid {
+			t.Errorf("expected valid to be false, got true")
+		}
+		if resp.Error == "" {
+			t.Errorf("expected error message, got empty")
+		}
+	})
+
+	t.Run("task validation unsupported", func(t *testing.T) {
+		reqBody, _ := json.Marshal(ValidateRequest{
+			Type: "task",
+			SQL:  "SELECT 1",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/validate", bytes.NewReader(reqBody))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		handler := Validate(app)
+		if err := handler(c); err != nil {
+			t.Fatalf("handler failed: %v", err)
+		}
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		reqBody, _ := json.Marshal(ValidateRequest{
+			Type: "invalid",
+			SQL:  "SELECT 1",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/validate", bytes.NewReader(reqBody))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		handler := Validate(app)
+		if err := handler(c); err != nil {
+			t.Fatalf("handler failed: %v", err)
+		}
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400, got %d", rec.Code)
+		}
+	})
+}

--- a/server/web/routes.go
+++ b/server/web/routes.go
@@ -161,6 +161,7 @@ func routes(e *echo.Echo, app *core.App, frontendFS fs.FS, modTime time.Time, cu
 	e.POST("/api/invites/:code/claim", handler.ClaimInvite(app))
 	e.POST("/api/data/:table_name", handler.PostEvent(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionIngestData))
 	e.POST("/api/deploy", handler.Deploy(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionDeploy))
+	e.POST("/api/validate", handler.Validate(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionDeploy))
 	e.POST("/api/sql", handler.ExecuteSQL(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionQueryData))
 	e.POST("/api/download/:filename", handler.DownloadSQL(app, internalUrl, pdfDateFormat), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionQueryData))
 	e.GET("/api/apps", handler.ListApps(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionDeploy))

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -90,11 +90,11 @@ export const Route = createFileRoute("/")({
   component: Index,
 });
 
-function DashboardErrorComponent({ error }: ErrorComponentProps) {
+function DashboardErrorComponent ({ error }: ErrorComponentProps) {
   return <ErrorComponent error={error} />;
 }
 
-function Index() {
+function Index () {
   const data = Route.useLoaderData();
   const { sort, order, path = "/" } = Route.useSearch();
   const navigate = useNavigate({ from: "/" });
@@ -1088,7 +1088,7 @@ function Index() {
   );
 }
 
-function RuntimeTooltip({
+function RuntimeTooltip ({
   lastRunAt,
   nextRunAt,
   nextRunType,

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -90,11 +90,11 @@ export const Route = createFileRoute("/")({
   component: Index,
 });
 
-function DashboardErrorComponent ({ error }: ErrorComponentProps) {
+function DashboardErrorComponent({ error }: ErrorComponentProps) {
   return <ErrorComponent error={error} />;
 }
 
-function Index () {
+function Index() {
   const data = Route.useLoaderData();
   const { sort, order, path = "/" } = Route.useSearch();
   const navigate = useNavigate({ from: "/" });
@@ -635,19 +635,21 @@ function Index () {
                 aria-hidden={true}
               />
               <p className="mt-2 mb-3 font-medium text-ctext dark:text-dtext">
-                {path === "/"
-                  ? "Create a first dashboard"
-                  : getSystemConfig().tasksEnabled ? "Create a dashboard or task" : "Create a dashboard"}
+                {getSystemConfig().editEnabled
+                  ? getSystemConfig().tasksEnabled ? "Create a dashboard or task" : "Create a dashboard"
+                  : "System is set to read-only. Create a first dashboard or task as file, deploy them and they will show up here."}
               </p>
-              <Link to="/new" search={{ path }}>
-                <Button>
-                  <RiAddFill
-                    className="-ml-1 mr-0.5 size-5 shrink-0"
-                    aria-hidden={true}
-                  />
-                  New
-                </Button>
-              </Link>
+              {getSystemConfig().editEnabled && (
+                <Link to="/new" search={{ path }}>
+                  <Button>
+                    <RiAddFill
+                      className="-ml-1 mr-0.5 size-5 shrink-0"
+                      aria-hidden={true}
+                    />
+                    New
+                  </Button>
+                </Link>
+              )}
             </div>
           ) : (
             <TableRoot className="h-full overflow-y-auto">
@@ -1086,7 +1088,7 @@ function Index () {
   );
 }
 
-function RuntimeTooltip ({
+function RuntimeTooltip({
   lastRunAt,
   nextRunAt,
   nextRunType,
@@ -1097,7 +1099,7 @@ function RuntimeTooltip ({
   nextRunType?: string;
   children?: React.ReactNode;
 }) {
-  if (lastRunAt == null && nextRunAt == null && nextRunType !== "init") {return children;}
+  if (lastRunAt == null && nextRunAt == null && nextRunType !== "init") { return children; }
   const tooltipContent = (
     <>
       {lastRunAt != null && (


### PR DESCRIPTION
This two commands will improve agent-based workflows:
1. Agent can validate and fix errors automatically.
2. Once agent is done it can give user a preview link to check dashboard.

`shaper validate [files...]`
Validates dashboard files specified or dashboards found in specified folders by running them.
Doesn't return data to CLI, but returns if there are any errors.
Also fails if file is missing ID comment.
Not validating tasks for now. More tricky since we don't want to casually run them.
This works with user auth or with an API key with `deploy` permissions. We will add this to Github action to run it in CI.

`shaper preview path/to/my-dashboard.dashboard.sql`
Creates a temporary dashboard for the given file.
Automatically opens the file in the browser.
Similar to running `shaper dev` in the background, but doesn't require keeping anything running in the background.

