### PR TITLE
Add Heatmap chart type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ FROM dataset
 GROUP BY ALL ORDER BY ALL;
 ```
 
+Render a GitHub-style calendar heatmap of date-based activity with `::HEATMAP`:
+
+```sql
+SELECT 'Activity'::LABEL;
+
+SELECT
+  date_trunc('day', created_at)::XAXIS,
+  count(*)::HEATMAP
+FROM events
+GROUP BY ALL
+ORDER BY ALL;
+```
+
 [
 ![Screenshot](https://taleshape.com/images/session_dashboard.png)
 ](https://taleshape.com/shaper/docs/)

--- a/server/core/custom_types.go
+++ b/server/core/custom_types.go
@@ -56,6 +56,7 @@ var dbTypes = []struct {
 	{"SCHEDULE_ALL", "UNION(\"schedule_all_timestamp\" TIMESTAMP, \"schedule_all_timestamptz\" TIMESTAMPTZ, \"schedule_all_interval\" INTERVAL, \"schedule_all_varchar\" VARCHAR)", "timestamp"},
 	{"GAUGE", "UNION(\"gauge_interval\" INTERVAL, \"gauge_double\" DOUBLE)", "chart"},
 	{"GAUGE_PERCENT", "UNION(\"gauge_percent\" DOUBLE)", "percent"},
+	{"HEATMAP", "UNION(\"heatmap_double\" DOUBLE)", "chart"},
 	{"PIECHART", "UNION(\"piechart_double\" DOUBLE)", "chart"},
 	{"PIECHART_PERCENT", "UNION(\"piechart_percent_double\" DOUBLE)", "percent"},
 	{"PIECHART_CATEGORY", "UNION(\"piechart_category_varchar\" VARCHAR)", "string"},

--- a/server/core/get_dashboard.go
+++ b/server/core/get_dashboard.go
@@ -484,7 +484,7 @@ func GetDashboard(app *App, ctx context.Context, dashboardId string, queryParams
 }
 
 func mapTag(index int, rInfo renderInfo) string {
-	if rInfo.Type == "linechart" || rInfo.Type == "barchartHorizontal" || rInfo.Type == "barchartHorizontalStacked" || rInfo.Type == "barchartVertical" || rInfo.Type == "barchartVerticalStacked" || rInfo.Type == "boxplot" || rInfo.Type == "piechart" || rInfo.Type == "donutchart" {
+	if rInfo.Type == "linechart" || rInfo.Type == "barchartHorizontal" || rInfo.Type == "barchartHorizontalStacked" || rInfo.Type == "barchartVertical" || rInfo.Type == "barchartVerticalStacked" || rInfo.Type == "boxplot" || rInfo.Type == "piechart" || rInfo.Type == "donutchart" || rInfo.Type == "calendarHeatmap" {
 		if rInfo.IndexAxisIndex != nil && index == *rInfo.IndexAxisIndex {
 			return "index"
 		}
@@ -1181,6 +1181,16 @@ func getRenderInfo(columns []*sql.ColumnType, rows Rows, label string, markLines
 			r.ColorIndex = &pieColorIndex
 		}
 		return r
+	}
+
+	heatmap, heatmapIndex := findColumnByTag(columns, "HEATMAP")
+	if heatmap != nil && xaxis != nil {
+		return renderInfo{
+			Label:          labelValue,
+			Type:           "calendarHeatmap",
+			IndexAxisIndex: &xaxisIndex,
+			ValueAxisIndex: &heatmapIndex,
+		}
 	}
 
 	boxplotIndex := findBoxlotColumnIndex(columns)

--- a/ui/src/components/charts/EChart.tsx
+++ b/ui/src/components/charts/EChart.tsx
@@ -4,7 +4,7 @@ import { useMemo, useRef, useEffect } from "react";
 import { debounce } from "lodash";
 
 import * as echarts from "echarts/core";
-import { BarChart, LineChart, GaugeChart, BoxplotChart, ScatterChart, PieChart } from "echarts/charts";
+import { BarChart, LineChart, GaugeChart, BoxplotChart, ScatterChart, PieChart, HeatmapChart } from "echarts/charts";
 import {
   TitleComponent,
   TooltipComponent,
@@ -18,6 +18,8 @@ import {
   LegendPlainComponent,
   LegendScrollComponent,
   MarkLineComponent,
+  CalendarComponent,
+  VisualMapComponent,
 } from "echarts/components";
 import { LabelLayout, UniversalTransition } from "echarts/features";
 import { CanvasRenderer, SVGRenderer } from "echarts/renderers";
@@ -38,6 +40,7 @@ echarts.use([
   BoxplotChart,
   ScatterChart,
   PieChart,
+  HeatmapChart,
   TitleComponent,
   TooltipComponent,
   GridComponent,
@@ -51,6 +54,8 @@ echarts.use([
   LegendPlainComponent,
   LegendScrollComponent,
   MarkLineComponent,
+  CalendarComponent,
+  VisualMapComponent,
   LabelLayout,
   UniversalTransition,
   // SVG renderer as default because it looks sharper

--- a/ui/src/components/charts/HeatmapChart.tsx
+++ b/ui/src/components/charts/HeatmapChart.tsx
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import React, { useCallback, useRef } from "react";
+import type { ECharts } from "echarts/core";
+import {
+  getThemeColors,
+  getChartFont,
+  getDisplayFont,
+} from "../../lib/chartUtils";
+import { cx } from "../../lib/utils";
+import { DarkModeContext } from "../../contexts/DarkModeContext";
+import { echartsEncode } from "../../lib/render";
+import { EChart } from "./EChart";
+
+interface HeatmapChartProps extends React.HTMLAttributes<HTMLDivElement> {
+  chartId: string;
+  label?: string;
+  data: [string, number][];
+  valueFormatter: (value: number) => string;
+  valueColumnName?: string;
+}
+
+const chartPadding = 16;
+
+const HeatmapChart = (props: HeatmapChartProps) => {
+  const {
+    data,
+    valueFormatter,
+    valueColumnName,
+    className,
+    chartId,
+    label,
+    ...other
+  } = props;
+
+  const chartRef = useRef<ECharts | null>(null);
+  const [chartWidth, setChartWidth] = React.useState(450);
+  const [chartHeight, setChartHeight] = React.useState(300);
+  const { isDarkMode } = React.useContext(DarkModeContext);
+
+  const chartOptions = React.useMemo(() => {
+    const theme = getThemeColors(isDarkMode);
+    const chartFont = getChartFont();
+    const displayFont = getDisplayFont();
+
+    // Determine year range from data
+    const years = new Set<number>();
+    let minValue = Infinity;
+    let maxValue = -Infinity;
+    data.forEach(([date, value]) => {
+      const y = Number.parseInt(date.slice(0, 4), 10);
+      if (Number.isFinite(y)) {
+        years.add(y);
+      }
+      if (typeof value === "number" && Number.isFinite(value)) {
+        if (value < minValue) minValue = value;
+        if (value > maxValue) maxValue = value;
+      }
+    });
+
+    if (!Number.isFinite(minValue)) {
+      minValue = 0;
+    }
+    if (!Number.isFinite(maxValue)) {
+      maxValue = 0;
+    }
+    // visualMap requires min < max
+    if (minValue === maxValue) {
+      if (maxValue === 0) {
+        maxValue = 1;
+      } else {
+        minValue = Math.min(0, minValue);
+      }
+    }
+
+    const sortedYears = Array.from(years).sort((a, b) => a - b);
+    const currentYear = new Date().getUTCFullYear();
+    const rangeYears = sortedYears.length > 0 ? sortedYears : [currentYear];
+
+    const labelTopOffset = label
+      ? 40 + 15 * (Math.ceil(label.length / (0.125 * chartWidth)) - 1)
+      : 25;
+
+    // Layout calendars stacked vertically when multiple years are present
+    const calendars = rangeYears.map((year, idx) => {
+      const yearGap = 18;
+      const yearHeight = Math.max(
+        80,
+        (chartHeight - labelTopOffset - chartPadding * 2 - 50 - (rangeYears.length - 1) * yearGap) /
+          rangeYears.length,
+      );
+      const top = labelTopOffset + chartPadding + idx * (yearHeight + yearGap);
+      return {
+        range: year.toString(),
+        top,
+        left: 50,
+        right: 20,
+        cellSize: ["auto", Math.max(10, Math.min(20, yearHeight / 9))],
+        orient: "horizontal",
+        splitLine: {
+          show: true,
+          lineStyle: {
+            color: theme.borderColor,
+            width: 1,
+            type: "solid",
+          },
+        },
+        itemStyle: {
+          color: theme.backgroundColorSecondary,
+          borderColor: theme.borderColor,
+          borderWidth: 0.5,
+        },
+        yearLabel: {
+          show: rangeYears.length > 1,
+          color: theme.textColorSecondary,
+          fontFamily: chartFont,
+          fontSize: 12,
+        },
+        monthLabel: {
+          color: theme.textColorSecondary,
+          fontFamily: chartFont,
+          fontSize: 11,
+        },
+        dayLabel: {
+          color: theme.textColorSecondary,
+          fontFamily: chartFont,
+          fontSize: 10,
+          firstDay: 1,
+        },
+      };
+    });
+
+    const series = rangeYears.map((year, idx) => ({
+      type: "heatmap" as const,
+      coordinateSystem: "calendar" as const,
+      calendarIndex: idx,
+      data: data.filter(([d]) => d.startsWith(year.toString())),
+    }));
+
+    return {
+      title: [
+        {
+          text: label,
+          textStyle: {
+            fontSize: 15,
+            lineHeight: 15,
+            fontFamily: displayFont,
+            fontWeight: 600,
+            color: theme.textColor,
+            width: chartWidth - 10 - 2 * chartPadding,
+            overflow: "break",
+          },
+          left: "center",
+          top: chartPadding,
+        },
+      ],
+      tooltip: {
+        trigger: "item",
+        confine: true,
+        backgroundColor: undefined,
+        borderColor: theme.borderColor,
+        className: "bg-cbg dark:bg-dbg",
+        textStyle: {
+          fontFamily: chartFont,
+          color: theme.textColor,
+        },
+        formatter: (params: any) => {
+          if (!params.value || !Array.isArray(params.value)) {
+            return "";
+          }
+          const [date, value] = params.value;
+          const formattedValue = echartsEncode(
+            valueFormatter(typeof value === "number" ? value : Number(value) || 0),
+          );
+          let html = `<div class="text-sm"><div class="font-medium">${echartsEncode(date)}</div>`;
+          if (valueColumnName) {
+            html += `<div class="mt-1 flex justify-between space-x-2"><span class="font-medium">${echartsEncode(valueColumnName)}</span><span>${formattedValue}</span></div>`;
+          } else {
+            html += `<div class="mt-1">${formattedValue}</div>`;
+          }
+          html += "</div>";
+          return html;
+        },
+      },
+      visualMap: {
+        min: minValue,
+        max: maxValue,
+        calculable: false,
+        orient: "horizontal",
+        left: "center",
+        bottom: 0,
+        itemWidth: 12,
+        itemHeight: 120,
+        textStyle: {
+          color: theme.textColorSecondary,
+          fontFamily: chartFont,
+          fontSize: 11,
+        },
+        inRange: {
+          color: isDarkMode
+            ? ["#0e4429", "#006d32", "#26a641", "#39d353"]
+            : ["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"],
+        },
+      },
+      calendar: calendars,
+      series,
+    };
+  }, [data, isDarkMode, chartWidth, chartHeight, label, valueFormatter, valueColumnName]);
+
+  const handleChartReady = useCallback((chart: ECharts) => {
+    chartRef.current = chart;
+    setChartWidth(chart.getWidth());
+    setChartHeight(chart.getHeight());
+  }, []);
+
+  const handleChartResize = useCallback((chart: ECharts) => {
+    setChartWidth(chart.getWidth());
+    setChartHeight(chart.getHeight());
+  }, []);
+
+  return (
+    <div
+      className={cx("h-full w-full relative select-none overflow-hidden", className)}
+      {...other}
+    >
+      <EChart
+        className="relative h-full w-full"
+        option={chartOptions}
+        onChartReady={handleChartReady}
+        onResize={handleChartResize}
+        data-chart-id={chartId}
+      />
+    </div>
+  );
+};
+
+HeatmapChart.displayName = "HeatmapChart";
+
+export { HeatmapChart, type HeatmapChartProps };

--- a/ui/src/components/dashboard/DashboardHeatmap.tsx
+++ b/ui/src/components/dashboard/DashboardHeatmap.tsx
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { useCallback, useMemo } from "react";
+import { Column } from "../../lib/types";
+import { HeatmapChart } from "../charts/HeatmapChart";
+import { formatValue, formatCellValue } from "../../lib/render";
+import { getNameIfSet } from "../../lib/utils";
+
+type HeatmapProps = {
+  chartId: string;
+  label?: string;
+  headers: Column[];
+  data: (string | number | boolean)[][];
+};
+
+const pad2 = (n: number) => n.toString().padStart(2, "0");
+
+const toIsoDate = (value: string | number | boolean | null | undefined): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  // Backend serializes time-typed columns as Unix ms numbers (or pre-formatted strings).
+  const d = new Date(value as string | number);
+  if (Number.isNaN(d.getTime())) {
+    return null;
+  }
+  // Use UTC components — backend interprets dates in UTC for consistency across timezones.
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+};
+
+const DashboardHeatmap = ({
+  chartId,
+  label,
+  headers,
+  data,
+}: HeatmapProps) => {
+  const valueIndex = headers.findIndex((c) => c.tag === "value");
+  if (valueIndex === -1) {
+    throw new Error("No column with tag 'value'");
+  }
+  const indexAxisIndex = headers.findIndex((c) => c.tag === "index");
+  if (indexAxisIndex === -1) {
+    throw new Error("No column with tag 'index'");
+  }
+  const valueHeader = headers[valueIndex];
+
+  const heatmapData = useMemo(() => {
+    const out: [string, number][] = [];
+    data.forEach((row) => {
+      const date = toIsoDate(row[indexAxisIndex] as string | number);
+      if (!date) {
+        return;
+      }
+      const raw = formatCellValue(row[valueIndex]);
+      const value = typeof raw === "number" ? raw : Number(raw);
+      if (!Number.isFinite(value)) {
+        return;
+      }
+      out.push([date, value]);
+    });
+    return out;
+  }, [data, indexAxisIndex, valueIndex]);
+
+  const valueFormatter = useCallback(
+    (n: number) => formatValue(n, valueHeader.type, true).toString(),
+    [valueHeader.type],
+  );
+
+  return (
+    <HeatmapChart
+      chartId={chartId}
+      label={label}
+      data={heatmapData}
+      valueColumnName={getNameIfSet(valueHeader.name)}
+      valueFormatter={valueFormatter}
+    />
+  );
+};
+
+export default DashboardHeatmap;

--- a/ui/src/components/dashboard/index.tsx
+++ b/ui/src/components/dashboard/index.tsx
@@ -23,6 +23,7 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { RiBarChartFill, RiCheckLine, RiFileCopyLine, RiLayoutFill, RiLoader3Fill } from "@remixicon/react";
 import DashboardGauge from "./DashboardGauge";
 import DashboardPieChart from "./DashboardPieChart";
+import DashboardHeatmap from "./DashboardHeatmap";
 import { ChartDownloadButton } from "../charts/ChartDownloadButton";
 import { TableDownloadButton } from "../charts/TableDownloadButton";
 import { FullscreenButton } from "./FullscreenButton";
@@ -444,7 +445,7 @@ const DataView = ({
                   }
                   const currentId = `${sectionIndex}-${queryIndex}`;
                   const isFullscreen = fullscreenId === currentId;
-                  const isBigChartQuery = query.render.type === "linechart" || query.render.type.startsWith("barchart") || query.render.type.startsWith("boxplot");
+                  const isBigChartQuery = query.render.type === "linechart" || query.render.type.startsWith("barchart") || query.render.type.startsWith("boxplot") || query.render.type === "calendarHeatmap";
                   const isChartQuery = isBigChartQuery || query.render.type === "gauge" || query.render.type === "piechart" || query.render.type === "donutchart";
                   const singleTable = numQueriesInSection === 1 && query.render.type === "table";
                   const sectionHasBigChart = section.queries.some(q => q.render.type !== "table" && q.render.type !== "value" && q.render.type !== "gauge" && q.render.type !== "piechart" && q.render.type !== "donutchart");
@@ -674,6 +675,16 @@ const renderContent = (
         headers={query.columns}
         data={query.rows}
         markLines={query.render.markLines}
+      />
+    );
+  }
+  if (query.render.type === "calendarHeatmap") {
+    return (
+      <DashboardHeatmap
+        chartId={`${sectionIndex}-${queryIndex}`}
+        label={query.render.label}
+        headers={query.columns}
+        data={query.rows as (string | number | boolean)[][]}
       />
     );
   }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -140,6 +140,7 @@ export type Result = {
           | "barchartVerticalStacked"
           | "piechart"
           | "donutchart"
+          | "calendarHeatmap"
           label?: string;
           markLines: MarkLine[];
         }


### PR DESCRIPTION
A new `HEATMAP` chart type to Shaper.

The new chart renders date-based numeric data as a GitHub-style calendar heatmap, useful for visualizing activity, contributions, usage, events, or other daily counts over time.

## Example

```sql
SELECT 'Activity'::LABEL;

SELECT
  date_trunc('day', created_at)::XAXIS,
  count(*)::HEATMAP
FROM events
GROUP BY ALL
ORDER BY ALL;
```
<img width="3610" height="413" alt="image" src="https://github.com/user-attachments/assets/7697f879-56a0-4949-99d2-fcb151b039b8" />
