### PR TITLE
Add `shaper schema` command

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,6 +258,7 @@ func buildRootCommand(ctx context.Context) *ff.Command {
 		addIdsSubcommand(rootCmd),
 		addDeploySubcommand(rootCmd),
 		addValidateSubcommand(rootCmd),
+		addSchemaSubcommand(rootCmd),
 	)
 
 	// Set up the root command execution
@@ -570,6 +571,30 @@ func addValidateSubcommand(rootCmd *ff.Command) *ff.Command {
 	}
 	rootCmd.Subcommands = append(rootCmd.Subcommands, validateCmd)
 	return validateCmd
+}
+
+func addSchemaSubcommand(rootCmd *ff.Command) *ff.Command {
+	schemaFlags := ff.NewFlagSet("schema")
+	help := schemaFlags.Bool('h', "help", "show help")
+	schemaConfigPath := schemaFlags.StringLong("config", "./shaper.json", "Path to config file")
+	schemaAuthFile := schemaFlags.StringLong("auth-file", ".shaper-auth", "Path to auth token file")
+
+	usage := "Show database schema as Markdown"
+	schemaCmd := &ff.Command{
+		Name:      "schema",
+		Usage:     "shaper schema [--config path] [--auth-file path]",
+		ShortHelp: usage,
+		Flags:     schemaFlags,
+		Exec: func(ctx context.Context, args []string) error {
+			if *help {
+				fmt.Printf("%s\n", ffhelp.Flags(schemaFlags, usage))
+				return nil
+			}
+			return dev.RunSchemaCommand(ctx, *schemaConfigPath, *schemaAuthFile)
+		},
+	}
+	rootCmd.Subcommands = append(rootCmd.Subcommands, schemaCmd)
+	return schemaCmd
 }
 
 func Run(cfg Config) func(context.Context) {

--- a/main.go
+++ b/main.go
@@ -524,9 +524,7 @@ func addDeploySubcommand(rootCmd *ff.Command) *ff.Command {
 	deployConfigPath := deployFlags.StringLong("config", "./shaper.json", "Path to config file")
 	deployValidateOnly := deployFlags.BoolLong("validate-only", "Run validation checks without applying any changes")
 
-	usage := `Deploy dashboards from files using API key auth.
-
-  Set SHAPER_DEPLOY_API_KEY to authenticate.`
+	usage := `Deploy dashboards from files using API key auth. Set SHAPER_DEPLOY_API_KEY to authenticate.`
 	deployCmd := &ff.Command{
 		Name:      "deploy",
 		Usage:     "shaper deploy [--config path]",
@@ -550,10 +548,10 @@ func addValidateSubcommand(rootCmd *ff.Command) *ff.Command {
 	validateConfigPath := validateFlags.StringLong("config", "./shaper.json", "Path to config file")
 
 	usage := `Validate dashboards and tasks.
-  
+
   If no files are passed, all dashboards in the configured directory are validated.
   Otherwise, pass file paths to .dashboard.sql files or folders.
-  
+
   Set SHAPER_DEPLOY_API_KEY to authenticate.`
 
 	validateCmd := &ff.Command{

--- a/server/api/types.go
+++ b/server/api/types.go
@@ -121,8 +121,6 @@ type Enum struct {
 // Extension represents a DuckDB extension.
 type Extension struct {
 	Name        string `json:"name"`
-	Loaded      bool   `json:"loaded"`
-	Installed   bool   `json:"installed"`
 	Description string `json:"description,omitempty"`
 }
 

--- a/server/api/types.go
+++ b/server/api/types.go
@@ -55,3 +55,81 @@ type AppsResponse struct {
 	Page     int   `json:"page"`
 	PageSize int   `json:"pageSize"`
 }
+
+// SchemaResponse represents the database schema.
+type SchemaResponse struct {
+	Databases  []Database  `json:"databases"`
+	Extensions []Extension `json:"extensions,omitempty"`
+	Secrets    []Secret    `json:"secrets,omitempty"`
+}
+
+// Database represents a database in the schema.
+type Database struct {
+	Name    string   `json:"name"`
+	Schemas []Schema `json:"schemas"`
+}
+
+// Schema represents a schema in the database.
+type Schema struct {
+	Name   string  `json:"name"`
+	Tables []Table `json:"tables"`
+	Views  []View  `json:"views"`
+	Enums  []Enum  `json:"enums"`
+}
+
+// Table represents a table in the schema.
+type Table struct {
+	Name        string       `json:"name"`
+	Comment     string       `json:"comment,omitempty"`
+	Columns     []Column     `json:"columns"`
+	Constraints []Constraint `json:"constraints,omitempty"`
+}
+
+// View represents a view in the schema.
+type View struct {
+	Name       string   `json:"name"`
+	Comment    string   `json:"comment,omitempty"`
+	Columns    []Column `json:"columns"`
+	Definition string   `json:"definition"` // The SQL DDL
+}
+
+// Column represents a column in a table or view.
+type Column struct {
+	Name     string  `json:"name"`
+	Type     string  `json:"type"`
+	Nullable bool    `json:"nullable"`
+	Default  *string `json:"default,omitempty"`
+	Comment  string  `json:"comment,omitempty"`
+}
+
+// Constraint represents a constraint on a table.
+type Constraint struct {
+	Name            string   `json:"name"`
+	Type            string   `json:"type"` // PRIMARY KEY, FOREIGN KEY, CHECK, UNIQUE
+	Columns         []string `json:"columns"`
+	ReferencedTable *string  `json:"referencedTable,omitempty"`
+	ReferencedCols  []string `json:"referencedCols,omitempty"`
+	CheckExpression *string  `json:"checkExpression,omitempty"`
+}
+
+// Enum represents an enum type.
+type Enum struct {
+	Name   string   `json:"name"`
+	Values []string `json:"values"`
+}
+
+// Extension represents a DuckDB extension.
+type Extension struct {
+	Name        string `json:"name"`
+	Loaded      bool   `json:"loaded"`
+	Installed   bool   `json:"installed"`
+	Description string `json:"description,omitempty"`
+}
+
+// Secret represents a DuckDB secret.
+type Secret struct {
+	Name     string   `json:"name"`
+	Type     string   `json:"type"`
+	Provider string   `json:"provider"`
+	Scope    []string `json:"scope,omitempty"`
+}

--- a/server/core/duckdb_schema.go
+++ b/server/core/duckdb_schema.go
@@ -1,0 +1,332 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"shaper/server/api"
+)
+
+func (app *App) GetSchema(ctx context.Context) (*api.SchemaResponse, error) {
+	db, cleanup, err := app.GetDuckDB(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DuckDB connection: %w", err)
+	}
+	defer cleanup()
+
+	// 1. Fetch Databases
+	var databases []struct {
+		Name string `db:"database_name"`
+	}
+	err = db.SelectContext(ctx, &databases, `
+		SELECT database_name
+		FROM duckdb_databases()
+		WHERE NOT internal AND database_name NOT IN ('sqlite', 'system', 'temp')
+		ORDER BY database_name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch databases: %w", err)
+	}
+
+	res := &api.SchemaResponse{
+		Databases:  make([]api.Database, 0, len(databases)),
+		Extensions: make([]api.Extension, 0),
+		Secrets:    make([]api.Secret, 0),
+	}
+
+	// Fetch Extensions
+	var extensions []struct {
+		Name        string `db:"extension_name"`
+		Loaded      bool   `db:"loaded"`
+		Installed   bool   `db:"installed"`
+		Description string `db:"description"`
+	}
+	_ = db.SelectContext(ctx, &extensions, `
+		SELECT extension_name, loaded, installed, description
+		FROM duckdb_extensions()
+		WHERE loaded AND installed AND extension_name NOT IN ('autocomplete', 'core_functions', 'icu', 'jemalloc', 'json', 'parquet')
+		ORDER BY extension_name
+	`)
+	for _, e := range extensions {
+		res.Extensions = append(res.Extensions, api.Extension{
+			Name:        e.Name,
+			Loaded:      e.Loaded,
+			Installed:   e.Installed,
+			Description: e.Description,
+		})
+	}
+
+	// Fetch Secrets
+	rows, err := db.QueryxContext(ctx, `
+		SELECT name, type, provider, scope
+		FROM duckdb_secrets()
+		ORDER BY name
+	`)
+	if err == nil {
+		for rows.Next() {
+			m := make(map[string]interface{})
+			if err := rows.MapScan(m); err == nil {
+				s := api.Secret{}
+				if val, ok := m["name"]; ok && val != nil {
+					s.Name = fmt.Sprint(val)
+				}
+				if val, ok := m["type"]; ok && val != nil {
+					s.Type = fmt.Sprint(val)
+				}
+				if val, ok := m["provider"]; ok && val != nil {
+					s.Provider = fmt.Sprint(val)
+				}
+				if val, ok := m["scope"]; ok && val != nil {
+					if scopes, ok := val.([]interface{}); ok {
+						for _, scope := range scopes {
+							s.Scope = append(s.Scope, fmt.Sprint(scope))
+						}
+					}
+				}
+				res.Secrets = append(res.Secrets, s)
+			}
+		}
+		rows.Close()
+	}
+
+	for _, d := range databases {
+		database := api.Database{
+			Name:    d.Name,
+			Schemas: make([]api.Schema, 0),
+		}
+
+		// 2. Fetch Schemas for this database
+		var schemas []struct {
+			Name string `db:"schema_name"`
+		}
+		err = db.SelectContext(ctx, &schemas, `
+			SELECT schema_name
+			FROM duckdb_schemas()
+			WHERE database_name = ? AND schema_name NOT IN ('information_schema', 'pg_catalog')
+			ORDER BY schema_name
+		`, d.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch schemas for %s: %w", d.Name, err)
+		}
+
+		for _, s := range schemas {
+			schema := api.Schema{
+				Name:   s.Name,
+				Tables: make([]api.Table, 0),
+				Views:  make([]api.View, 0),
+				Enums:  make([]api.Enum, 0),
+			}
+
+			// 3. Fetch Enums for this schema
+			// Note: duckdb_types() doesn't have database_name in some versions, but let's assume it does or use current
+			var enums []struct {
+				Name string `db:"type_name"`
+			}
+			db.SelectContext(ctx, &enums, `
+				SELECT type_name
+				FROM duckdb_types()
+				WHERE schema_name = ? AND logical_type = 'ENUM' AND NOT internal
+				ORDER BY type_name
+			`, s.Name)
+			// We ignore error here as duckdb_types might not have database_name or fail for other reasons,
+			// it's not critical for the whole schema
+
+			for _, e := range enums {
+				var values []string
+				// enum_range returns an array, which sqlx might struggle to scan directly into []string
+				// if not careful, but let's try.
+				query := fmt.Sprintf("SELECT enum_range(NULL::\"%s\".\"%s\")", s.Name, e.Name)
+				// DuckDB array to Go slice might need special handling if sqlx doesn't do it.
+				// For now let's just try to get it as a string if it fails.
+				var val interface{}
+				if err := db.GetContext(ctx, &val, query); err == nil {
+					if slice, ok := val.([]interface{}); ok {
+						for _, v := range slice {
+							if s, ok := v.(string); ok {
+								values = append(values, s)
+							}
+						}
+					}
+				}
+				schema.Enums = append(schema.Enums, api.Enum{
+					Name:   e.Name,
+					Values: values,
+				})
+			}
+
+			// 4. Fetch Tables
+			var tables []struct {
+				Name    string  `db:"table_name"`
+				Comment *string `db:"comment"`
+			}
+			err = db.SelectContext(ctx, &tables, `
+				SELECT table_name, comment
+				FROM duckdb_tables()
+				WHERE database_name = ? AND schema_name = ? AND NOT internal
+				ORDER BY table_name
+			`, d.Name, s.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch tables for %s.%s: %w", d.Name, s.Name, err)
+			}
+
+			for _, t := range tables {
+				table := api.Table{
+					Name:    t.Name,
+					Columns: make([]api.Column, 0),
+				}
+				if t.Comment != nil {
+					table.Comment = *t.Comment
+				}
+
+				// Fetch Columns
+				var columns []struct {
+					Name     string  `db:"column_name"`
+					Type     string  `db:"data_type"`
+					Nullable bool    `db:"is_nullable"`
+					Default  *string `db:"column_default"`
+					Comment  *string `db:"comment"`
+				}
+				err = db.SelectContext(ctx, &columns, `
+					SELECT column_name, data_type, is_nullable, column_default, comment
+					FROM duckdb_columns()
+					WHERE database_name = ? AND schema_name = ? AND table_name = ?
+					ORDER BY column_index
+				`, d.Name, s.Name, t.Name)
+				if err != nil {
+					return nil, fmt.Errorf("failed to fetch columns for %s.%s.%s: %w", d.Name, s.Name, t.Name, err)
+				}
+
+				for _, c := range columns {
+					col := api.Column{
+						Name:     c.Name,
+						Type:     c.Type,
+						Nullable: c.Nullable,
+						Default:  c.Default,
+					}
+					if c.Comment != nil {
+						col.Comment = *c.Comment
+					}
+					table.Columns = append(table.Columns, col)
+				}
+
+				// Fetch Constraints
+				rows, err := db.QueryxContext(ctx, `
+					SELECT *
+					FROM duckdb_constraints()
+					WHERE database_name = ? AND schema_name = ? AND table_name = ?
+				`, d.Name, s.Name, t.Name)
+				if err != nil {
+					// Fallback if database_name is not available (older duckdb?)
+					rows, err = db.QueryxContext(ctx, `
+						SELECT *
+						FROM duckdb_constraints()
+						WHERE schema_name = ? AND table_name = ?
+					`, s.Name, t.Name)
+				}
+
+				if err == nil {
+					for rows.Next() {
+						m := make(map[string]interface{})
+						if err := rows.MapScan(m); err == nil {
+							c := api.Constraint{}
+							if val, ok := m["constraint_name"]; ok && val != nil {
+								c.Name = fmt.Sprint(val)
+							}
+							if val, ok := m["constraint_type"]; ok && val != nil {
+								c.Type = fmt.Sprint(val)
+							}
+							// Try different possible column names for columns array
+							colKey := ""
+							if _, ok := m["constraint_column_names"]; ok {
+								colKey = "constraint_column_names"
+							} else if _, ok := m["column_names"]; ok {
+								colKey = "column_names"
+							}
+
+							if colKey != "" {
+								if cols, ok := m[colKey].([]interface{}); ok {
+									for _, col := range cols {
+										c.Columns = append(c.Columns, fmt.Sprint(col))
+									}
+								}
+							}
+
+							if val, ok := m["referenced_table"]; ok && val != nil {
+								s := fmt.Sprint(val)
+								c.ReferencedTable = &s
+							}
+
+							table.Constraints = append(table.Constraints, c)
+						}
+					}
+					rows.Close()
+				}
+
+				schema.Tables = append(schema.Tables, table)
+			}
+
+			// 5. Fetch Views
+			var views []struct {
+				Name       string  `db:"view_name"`
+				Comment    *string `db:"comment"`
+				Definition string  `db:"sql"`
+			}
+			err = db.SelectContext(ctx, &views, `
+				SELECT view_name, comment, sql
+				FROM duckdb_views()
+				WHERE database_name = ? AND schema_name = ? AND NOT internal
+				ORDER BY view_name
+			`, d.Name, s.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch views for %s.%s: %w", d.Name, s.Name, err)
+			}
+
+			for _, v := range views {
+				view := api.View{
+					Name:       v.Name,
+					Definition: v.Definition,
+					Columns:    make([]api.Column, 0),
+				}
+				if v.Comment != nil {
+					view.Comment = *v.Comment
+				}
+
+				// Fetch Columns for View
+				var columns []struct {
+					Name     string  `db:"column_name"`
+					Type     string  `db:"data_type"`
+					Nullable bool    `db:"is_nullable"`
+					Default  *string `db:"column_default"`
+					Comment  *string `db:"comment"`
+				}
+				err = db.SelectContext(ctx, &columns, `
+					SELECT column_name, data_type, is_nullable, column_default, comment
+					FROM duckdb_columns()
+					WHERE database_name = ? AND schema_name = ? AND table_name = ?
+					ORDER BY column_index
+				`, d.Name, s.Name, v.Name)
+				if err == nil {
+					for _, c := range columns {
+						col := api.Column{
+							Name:     c.Name,
+							Type:     c.Type,
+							Nullable: c.Nullable,
+							Default:  c.Default,
+						}
+						if c.Comment != nil {
+							col.Comment = *c.Comment
+						}
+						view.Columns = append(view.Columns, col)
+					}
+				}
+
+				schema.Views = append(schema.Views, view)
+			}
+
+			database.Schemas = append(database.Schemas, schema)
+		}
+
+		res.Databases = append(res.Databases, database)
+	}
+
+	return res, nil
+}

--- a/server/core/duckdb_schema.go
+++ b/server/core/duckdb_schema.go
@@ -20,7 +20,7 @@ func (app *App) GetSchema(ctx context.Context) (*api.SchemaResponse, error) {
 	err = db.SelectContext(ctx, &databases, `
 		SELECT database_name
 		FROM duckdb_databases()
-		WHERE NOT internal AND database_name NOT IN ('sqlite', 'system', 'temp')
+		WHERE NOT internal
 		ORDER BY database_name
 	`)
 	if err != nil {
@@ -36,12 +36,10 @@ func (app *App) GetSchema(ctx context.Context) (*api.SchemaResponse, error) {
 	// Fetch Extensions
 	var extensions []struct {
 		Name        string `db:"extension_name"`
-		Loaded      bool   `db:"loaded"`
-		Installed   bool   `db:"installed"`
 		Description string `db:"description"`
 	}
 	_ = db.SelectContext(ctx, &extensions, `
-		SELECT extension_name, loaded, installed, description
+		SELECT extension_name, description
 		FROM duckdb_extensions()
 		WHERE loaded AND installed AND extension_name NOT IN ('autocomplete', 'core_functions', 'icu', 'jemalloc', 'json', 'parquet')
 		ORDER BY extension_name
@@ -49,8 +47,6 @@ func (app *App) GetSchema(ctx context.Context) (*api.SchemaResponse, error) {
 	for _, e := range extensions {
 		res.Extensions = append(res.Extensions, api.Extension{
 			Name:        e.Name,
-			Loaded:      e.Loaded,
-			Installed:   e.Installed,
 			Description: e.Description,
 		})
 	}

--- a/server/core/duckdb_schema_test.go
+++ b/server/core/duckdb_schema_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func TestGetSchema(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "shaper-test-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	sqlitePath := filepath.Join(tmpDir, "test.sqlite")
+	duckdbPath := filepath.Join(tmpDir, "test.duckdb")
+
+	sqliteDbx, err := sqlx.Connect("sqlite", sqlitePath)
+	assert.NoError(t, err)
+	defer sqliteDbx.Close()
+
+	err = initSQLite(sqliteDbx)
+	assert.NoError(t, err)
+
+	duckdbDbx, err := sqlx.Connect("duckdb", duckdbPath)
+	assert.NoError(t, err)
+	defer duckdbDbx.Close()
+
+	// Create some test data in DuckDB
+	_, err = duckdbDbx.Exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			email TEXT UNIQUE,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		);
+		COMMENT ON TABLE users IS 'A table of users';
+		COMMENT ON COLUMN users.name IS 'The user''s full name';
+
+		CREATE VIEW active_users AS SELECT * FROM users WHERE name IS NOT NULL;
+		COMMENT ON VIEW active_users IS 'Only active users';
+
+		CREATE TYPE mood AS ENUM ('happy', 'sad', 'ok');
+		CREATE TABLE feelings (
+			user_id INTEGER,
+			current_mood mood,
+			FOREIGN KEY (user_id) REFERENCES users(id)
+		);
+	`)
+	assert.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	app := &App{
+		Sqlite:    sqliteDbx,
+		DuckDB:    duckdbDbx,
+		DuckDBDSN: duckdbPath,
+		Logger:    logger,
+	}
+
+	res, err := app.GetSchema(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	// Verify the schema structure
+	foundMain := false
+	for _, db := range res.Databases {
+		if db.Name == "test" || db.Name == "memory" || db.Name == "test.duckdb" || db.Name == "main" {
+			foundMain = true
+			foundDefault := false
+			for _, s := range db.Schemas {
+				if s.Name == "main" {
+					foundDefault = true
+					
+					// Check Tables
+					assert.Len(t, s.Tables, 2)
+					var usersTable *struct{Name string}
+					for _, table := range s.Tables {
+						if table.Name == "users" {
+							usersTable = &struct{Name string}{Name: table.Name}
+							assert.Equal(t, "A table of users", table.Comment)
+							assert.Len(t, table.Columns, 4)
+							assert.Equal(t, "id", table.Columns[0].Name)
+							assert.Equal(t, "name", table.Columns[1].Name)
+							assert.Equal(t, "The user's full name", table.Columns[1].Comment)
+							
+							// Check Constraints
+							assert.NotEmpty(t, table.Constraints)
+						}
+					}
+					assert.NotNil(t, usersTable)
+
+					// Check Views
+					assert.Len(t, s.Views, 1)
+					assert.Equal(t, "active_users", s.Views[0].Name)
+					assert.Contains(t, s.Views[0].Definition, "SELECT")
+
+					// Check Enums
+					assert.Len(t, s.Enums, 1)
+					assert.Equal(t, "mood", s.Enums[0].Name)
+					assert.ElementsMatch(t, []string{"happy", "sad", "ok"}, s.Enums[0].Values)
+				}
+			}
+			assert.True(t, foundDefault)
+		}
+	}
+	assert.True(t, foundMain)
+}

--- a/server/dev/schema.go
+++ b/server/dev/schema.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"shaper/server/api"
+	"strings"
+)
+
+func RunSchemaCommand(ctx context.Context, configPath, authFile string) error {
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	sysCfg, err := fetchSystemConfig(ctx, cfg.URL)
+	if err != nil {
+		return err
+	}
+
+	auth := NewAuthManager(ctx, cfg.URL, authFile, sysCfg.LoginRequired)
+	client, err := NewAPIClient(ctx, cfg.URL, auth)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.DoRequest(ctx, http.MethodGet, "/api/schema", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return decodeAPIError(resp)
+	}
+
+	var schema api.SchemaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&schema); err != nil {
+		return fmt.Errorf("failed to decode schema response: %w", err)
+	}
+
+	output := formatSchemaMarkdown(schema)
+	fmt.Print(output)
+
+	return nil
+}
+
+func formatSchemaMarkdown(schema api.SchemaResponse) string {
+	var sb strings.Builder
+	sb.WriteString("# Database Schema\n\n")
+
+	if len(schema.Extensions) > 0 {
+		sb.WriteString("## Loaded Extensions\n\n")
+		headers := []string{"Extension", "Description"}
+		rows := make([][]string, 0, len(schema.Extensions))
+		for _, e := range schema.Extensions {
+			rows = append(rows, []string{e.Name, e.Description})
+		}
+		sb.WriteString(formatPaddedTable(headers, rows))
+		sb.WriteString("\n")
+	}
+
+	if len(schema.Secrets) > 0 {
+		sb.WriteString("## Secrets\n\n")
+		headers := []string{"Name", "Type", "Provider", "Scope"}
+		rows := make([][]string, 0, len(schema.Secrets))
+		for _, s := range schema.Secrets {
+			rows = append(rows, []string{s.Name, s.Type, s.Provider, strings.Join(s.Scope, ", ")})
+		}
+		sb.WriteString(formatPaddedTable(headers, rows))
+		sb.WriteString("\n")
+	}
+
+	for _, db := range schema.Databases {
+		dbHasContent := false
+		var dbSb strings.Builder
+		dbSb.WriteString(fmt.Sprintf("## Database: %s\n\n", db.Name))
+
+		for _, s := range db.Schemas {
+			if len(s.Tables) == 0 && len(s.Views) == 0 && len(s.Enums) == 0 {
+				continue
+			}
+			dbHasContent = true
+			dbSb.WriteString(fmt.Sprintf("### Schema: %s\n\n", s.Name))
+
+			if len(s.Enums) > 0 {
+				dbSb.WriteString("#### Enums\n\n")
+				dbSb.WriteString("```sql\n")
+				for _, e := range s.Enums {
+					values := make([]string, len(e.Values))
+					for i, v := range e.Values {
+						values[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''"))
+					}
+					dbSb.WriteString(fmt.Sprintf("CREATE TYPE \"%s\".\"%s\" AS ENUM (%s);\n", s.Name, e.Name, strings.Join(values, ", ")))
+				}
+				dbSb.WriteString("```\n\n")
+			}
+
+			if len(s.Tables) > 0 {
+				dbSb.WriteString("#### Tables\n\n")
+				for _, t := range s.Tables {
+					if t.Comment != "" {
+						dbSb.WriteString(t.Comment + "\n\n")
+					}
+
+					// Filter out NOT NULL constraints as they are handled inline
+					var activeConstraints []api.Constraint
+					for _, c := range t.Constraints {
+						if c.Type != "NOT NULL" {
+							activeConstraints = append(activeConstraints, c)
+						}
+					}
+
+					dbSb.WriteString("```sql\n")
+					if t.Comment != "" {
+						dbSb.WriteString(fmt.Sprintf("-- %s\n", t.Comment))
+					}
+					dbSb.WriteString(fmt.Sprintf("CREATE TABLE \"%s\".\"%s\".\"%s\" (\n", db.Name, s.Name, t.Name))
+					for i, col := range t.Columns {
+						if col.Comment != "" {
+							dbSb.WriteString(fmt.Sprintf("    -- %s\n", col.Comment))
+						}
+						line := fmt.Sprintf("    \"%s\" %s", col.Name, col.Type)
+						if !col.Nullable {
+							line += " NOT NULL"
+						}
+						if col.Default != nil {
+							line += fmt.Sprintf(" DEFAULT %s", *col.Default)
+						}
+						if i < len(t.Columns)-1 || len(activeConstraints) > 0 {
+							line += ","
+						}
+						dbSb.WriteString(line + "\n")
+					}
+					for i, c := range activeConstraints {
+						line := "    "
+						switch c.Type {
+						case "PRIMARY KEY":
+							line += fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(quoteIdentifiers(c.Columns), ", "))
+						case "FOREIGN KEY":
+							refTable := ""
+							if c.ReferencedTable != nil {
+								refTable = *c.ReferencedTable
+							}
+							line += fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s", strings.Join(quoteIdentifiers(c.Columns), ", "), refTable)
+						case "UNIQUE":
+							line += fmt.Sprintf("UNIQUE (%s)", strings.Join(quoteIdentifiers(c.Columns), ", "))
+						case "CHECK":
+							expr := ""
+							if c.CheckExpression != nil {
+								expr = *c.CheckExpression
+							}
+							line += fmt.Sprintf("CHECK (%s)", expr)
+						default:
+							line += fmt.Sprintf("CONSTRAINT \"%s\" %s", c.Name, c.Type)
+						}
+						if i < len(activeConstraints)-1 {
+							line += ","
+						}
+						dbSb.WriteString(line + "\n")
+					}
+					dbSb.WriteString(");\n")
+					dbSb.WriteString("```\n\n")
+				}
+			}
+
+			if len(s.Views) > 0 {
+				dbSb.WriteString("#### Views\n\n")
+				for _, v := range s.Views {
+					dbSb.WriteString(fmt.Sprintf("##### View: \"%s\".\"%s\"\n\n", s.Name, v.Name))
+					if v.Comment != "" {
+						dbSb.WriteString(v.Comment + "\n\n")
+					}
+
+					// Show columns table
+					if len(v.Columns) > 0 {
+						headers := []string{"Column", "Type", "Comment"}
+						rows := make([][]string, 0, len(v.Columns))
+						for _, col := range v.Columns {
+							rows = append(rows, []string{
+								col.Name,
+								col.Type,
+								col.Comment,
+							})
+						}
+						dbSb.WriteString(formatPaddedTable(headers, rows))
+						dbSb.WriteString("\n")
+					}
+
+					dbSb.WriteString("```sql\n")
+					if v.Definition != "" {
+						dbSb.WriteString(v.Definition + "\n")
+					} else {
+						// Fallback if definition is missing
+						dbSb.WriteString(fmt.Sprintf("CREATE VIEW \"%s\".\"%s\".\"%s\" AS ...\n", db.Name, s.Name, v.Name))
+					}
+					dbSb.WriteString("```\n\n")
+				}
+			}
+		}
+
+		if dbHasContent {
+			sb.WriteString(dbSb.String())
+		}
+	}
+
+	return sb.String()
+}
+
+func quoteIdentifiers(ids []string) []string {
+	quoted := make([]string, len(ids))
+	for i, id := range ids {
+		quoted[i] = fmt.Sprintf("\"%s\"", id)
+	}
+	return quoted
+}
+
+func formatPaddedTable(headers []string, rows [][]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+
+	for _, row := range rows {
+		for i, val := range row {
+			if i < len(widths) && len(val) > widths[i] {
+				widths[i] = len(val)
+			}
+		}
+	}
+
+	var sb strings.Builder
+
+	// Header
+	sb.WriteString("|")
+	for i, h := range headers {
+		sb.WriteString(fmt.Sprintf(" %-*s |", widths[i], h))
+	}
+	sb.WriteString("\n")
+
+	// Separator
+	sb.WriteString("|")
+	for _, w := range widths {
+		sb.WriteString(fmt.Sprintf(" %s |", strings.Repeat("-", w)))
+	}
+	sb.WriteString("\n")
+
+	// Rows
+	for _, row := range rows {
+		sb.WriteString("|")
+		for i, val := range row {
+			if i < len(widths) {
+				sb.WriteString(fmt.Sprintf(" %-*s |", widths[i], val))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}

--- a/server/web/handler/schema.go
+++ b/server/web/handler/schema.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package handler
+
+import (
+	"net/http"
+	"shaper/server/core"
+
+	"github.com/labstack/echo/v4"
+)
+
+func GetSchema(app *core.App) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		res, err := app.GetSchema(c.Request().Context())
+		if err != nil {
+			return c.JSONPretty(http.StatusInternalServerError, struct {
+				Error string `json:"error"`
+			}{Error: err.Error()}, "  ")
+		}
+		return c.JSONPretty(http.StatusOK, res, "  ")
+	}
+}

--- a/server/web/handler/schema.go
+++ b/server/web/handler/schema.go
@@ -6,11 +6,21 @@ import (
 	"net/http"
 	"shaper/server/core"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 )
 
 func GetSchema(app *core.App) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		ctxUser := c.Get("user")
+		if ctxUser != nil {
+			claims := ctxUser.(*jwt.Token).Claims.(jwt.MapClaims)
+			if _, hasId := claims["dashboardId"]; hasId {
+				return c.JSONPretty(http.StatusUnauthorized, struct {
+					Error string `json:"error"`
+				}{Error: "Unauthorized"}, "  ")
+			}
+		}
 		res, err := app.GetSchema(c.Request().Context())
 		if err != nil {
 			return c.JSONPretty(http.StatusInternalServerError, struct {

--- a/server/web/handler/schema_test.go
+++ b/server/web/handler/schema_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"shaper/server/core"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/labstack/echo/v4"
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func TestGetSchema(t *testing.T) {
+	e := echo.New()
+	
+	db, err := sqlx.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("failed to open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	app := &core.App{DuckDB: db}
+	
+	req := httptest.NewRequest(http.MethodGet, "/api/schema", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := GetSchema(app)
+	if err := handler(c); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	contentType := rec.Header().Get(echo.HeaderContentType)
+	if contentType != echo.MIMEApplicationJSON && contentType != echo.MIMEApplicationJSONCharsetUTF8 {
+		t.Errorf("expected json content type, got %s", contentType)
+	}
+}

--- a/server/web/routes.go
+++ b/server/web/routes.go
@@ -163,6 +163,7 @@ func routes(e *echo.Echo, app *core.App, frontendFS fs.FS, modTime time.Time, cu
 	e.POST("/api/deploy", handler.Deploy(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionDeploy))
 	e.POST("/api/validate", handler.Validate(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionDeploy))
 	e.POST("/api/sql", handler.ExecuteSQL(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionQueryData))
+	e.GET("/api/schema", handler.GetSchema(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionQueryData))
 	e.POST("/api/download/:filename", handler.DownloadSQL(app, internalUrl, pdfDateFormat), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionQueryData))
 	e.GET("/api/apps", handler.ListApps(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionDeploy))
 	e.GET("/api/public/:id/status", handler.GetDashboardStatus(app))


### PR DESCRIPTION
Returns the available database schema as markdown file. 
The output is intended to be readable by humans and LLMs. 
Tables are shown as SQL DDL to keep it compact.
For views we show both, the SQL DDL and the resulting columns as markdown table.
Tables/view/column comments are also included.
We also list which extensions are loaded and which secrets are configured. Of course not giving away the actual secret.