### PR TITLE
Dedicated schema:read permission for /api/schema

### DIFF
--- a/server/core/keys.go
+++ b/server/core/keys.go
@@ -20,12 +20,13 @@ import (
 const API_KEY_PREFIX = "shaperkey."
 
 const (
-	PermissionGenerateJWT = "jwt"
-	PermissionDeploy      = "deploy"
-	PermissionQueryData   = "data:query"
-	PermissionIngestData  = "data:ingest"
-	PermissionReadMetrics = "metrics"
+	PermissionGenerateJWT   = "jwt"
+	PermissionDeploy        = "deploy"
+	PermissionQueryData     = "data:query"
+	PermissionIngestData    = "data:ingest"
+	PermissionReadMetrics   = "metrics"
 	PermissionReadDashboard = "dashboard:read"
+	PermissionReadSchema    = "schema:read"
 )
 
 var AllPermissions = []string{
@@ -35,6 +36,7 @@ var AllPermissions = []string{
 	PermissionIngestData,
 	PermissionReadMetrics,
 	PermissionReadDashboard,
+	PermissionReadSchema,
 }
 
 type APIKey struct {

--- a/server/web/routes.go
+++ b/server/web/routes.go
@@ -163,7 +163,7 @@ func routes(e *echo.Echo, app *core.App, frontendFS fs.FS, modTime time.Time, cu
 	e.POST("/api/deploy", handler.Deploy(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionDeploy))
 	e.POST("/api/validate", handler.Validate(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionDeploy))
 	e.POST("/api/sql", handler.ExecuteSQL(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionQueryData))
-	e.GET("/api/schema", handler.GetSchema(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionQueryData))
+	e.GET("/api/schema", handler.GetSchema(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionReadSchema))
 	e.POST("/api/download/:filename", handler.DownloadSQL(app, internalUrl, pdfDateFormat), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor, RequirePermission(app, core.PermissionQueryData))
 	e.GET("/api/apps", handler.ListApps(app), jwtOrAPIKeyMiddleware(app, jwtMiddleware, SetActor(app), middleware.KeyAuthWithConfig(keyAuthConfig), apiKeyActor), RequirePermission(app, core.PermissionDeploy))
 	e.GET("/api/public/:id/status", handler.GetDashboardStatus(app))

--- a/ui/src/routes/admin.keys.tsx
+++ b/ui/src/routes/admin.keys.tsx
@@ -60,6 +60,7 @@ const PERMISSIONS = [
   { label: "Ingest Data", value: "data:ingest" },
   { label: "Read Metrics", value: "metrics" },
   { label: "Read Dashboard", value: "dashboard:read" },
+  { label: "Read Database Schema", value: "schema:read" },
 ];
 
 interface NewAPIKeyResponse {


### PR DESCRIPTION
When using API key auth.
Before, this required data:read. This gives more control.