### PR TITLE
Fix: JWT variables must overwrite dashboard variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5987,9 +5987,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001757",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
-      "integrity": "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {

--- a/server/core/get_dashboard.go
+++ b/server/core/get_dashboard.go
@@ -231,7 +231,7 @@ func QueryDashboard(app *App, ctx context.Context, dashboardQuery DashboardQuery
 			}
 		}
 
-		err = collectVars(singleVars, multiVars, rInfo.Type, queryParams, query.Columns, query.Rows)
+		err = collectVars(singleVars, multiVars, variables, rInfo.Type, queryParams, query.Columns, query.Rows)
 		if err != nil {
 			return result, err
 		}
@@ -458,7 +458,7 @@ func ValidateDashboardDownload(app *App, ctx context.Context, sourceDashboardId 
 			})
 		}
 
-		err = collectVars(singleVars, multiVars, rInfo.Type, queryParams, columns, queryRows)
+		err = collectVars(singleVars, multiVars, variables, rInfo.Type, queryParams, columns, queryRows)
 		if err != nil {
 			return false, err
 		}
@@ -1416,7 +1416,7 @@ func getAxisType(rows Rows, index int) (string, error) {
 // TODO: test and harden variable escaping
 // TODO: assert that variables in query are set. otherwise it silently falls back to empty string
 // NOTE: Technically we don't need to reset variables since we are not reusing connections. I just have a better feeling with this.
-func collectVars(singleVars map[string]string, multiVars map[string][]string, renderType string, queryParams url.Values, columns []Column, data Rows) error {
+func collectVars(singleVars map[string]string, multiVars map[string][]string, protectedVariables map[string]any, renderType string, queryParams url.Values, columns []Column, data Rows) error {
 	// Fetch vars from dropdown
 	if renderType == "dropdown" {
 		columnName := ""
@@ -1430,6 +1430,9 @@ func collectVars(singleVars map[string]string, multiVars map[string][]string, re
 		}
 		if columnName == "" {
 			return fmt.Errorf("missing value column for dropdown")
+		}
+		if _, protected := protectedVariables[columnName]; protected {
+			return nil
 		}
 		param := queryParams.Get(columnName)
 		if param != "" {
@@ -1493,6 +1496,9 @@ func collectVars(singleVars map[string]string, multiVars map[string][]string, re
 		}
 		if columnName == "" {
 			return fmt.Errorf("missing value column for dropdownMulti")
+		}
+		if _, protected := protectedVariables[columnName]; protected {
+			return nil
 		}
 		params := queryParams[columnName]
 		paramWasProvided := queryParams.Has(columnName)
@@ -1574,6 +1580,9 @@ func collectVars(singleVars map[string]string, multiVars map[string][]string, re
 		if columnName == "" {
 			return fmt.Errorf("missing datepicker column")
 		}
+		if _, protected := protectedVariables[columnName]; protected {
+			return nil
+		}
 		param := queryParams.Get(columnName)
 		if param == "" {
 			// Set default value
@@ -1619,6 +1628,12 @@ func collectVars(singleVars map[string]string, multiVars map[string][]string, re
 		}
 		if toColumnName == "" {
 			return fmt.Errorf("missing DATEPICKER_TO column")
+		}
+		if _, protected := protectedVariables[fromColumnName]; protected {
+			return nil
+		}
+		if _, protected := protectedVariables[toColumnName]; protected {
+			return nil
 		}
 		fromParam := queryParams.Get(fromColumnName)
 		if fromParam == "" {
@@ -1671,6 +1686,9 @@ func collectVars(singleVars map[string]string, multiVars map[string][]string, re
 		}
 		if columnName == "" {
 			return fmt.Errorf("missing hint column for input")
+		}
+		if _, protected := protectedVariables[columnName]; protected {
+			return nil
 		}
 		param := queryParams.Get(columnName)
 		if param != "" {

--- a/server/core/get_dashboard_test.go
+++ b/server/core/get_dashboard_test.go
@@ -35,7 +35,7 @@ func TestValidateDashboardDownload(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert a dashboard that has a DOWNLOAD_PDF button
-	_, err = sdb.Exec(`INSERT INTO apps (id, type, name, content, created_at, updated_at, visibility) 
+	_, err = sdb.Exec(`INSERT INTO apps (id, type, name, content, created_at, updated_at, visibility)
 		VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), ?)`,
 		"source-dash", "dashboard", "Source", "SELECT 'target-dash'::ID, 'Download'::DOWNLOAD_PDF", "public")
 	if err != nil {
@@ -55,7 +55,7 @@ func TestValidateDashboardDownload(t *testing.T) {
 	})
 
 	// Dashboard with variable
-	_, err = sdb.Exec(`INSERT INTO apps (id, type, name, content, created_at, updated_at, visibility) 
+	_, err = sdb.Exec(`INSERT INTO apps (id, type, name, content, created_at, updated_at, visibility)
 		VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), ?)`,
 		"source-var-dash", "dashboard", "Source Var", "SELECT getvariable('target_id')::ID, 'Download'::DOWNLOAD_PDF", "public")
 	if err != nil {
@@ -111,5 +111,53 @@ func TestQueryDashboard(t *testing.T) {
 		result, err := QueryDashboard(app, ctx, dq, url.Values{}, map[string]any{"myvar": "hello"})
 		assert.NoError(t, err)
 		assert.Equal(t, "hello", result.Sections[0].Queries[0].Rows[0][0])
+	})
+
+	t.Run("Variable precedence - query param must NOT overwrite variables", func(t *testing.T) {
+		// This test fails if query params can overwrite secure variables.
+		// We have two queries:
+		// 1. A dropdown that defines 'myvar'
+		// 2. A query that uses 'myvar'
+		dq := DashboardQuery{
+			Content: `
+				SELECT 'secure_val'::DROPDOWN AS myvar, 'Secure'::LABEL AS label UNION ALL SELECT 'malicious_val', 'Malicious';
+				SELECT getvariable('myvar') AS val;
+			`,
+			ID: "test-precedence",
+		}
+
+		// Secure variable set to 'secure_val'
+		variables := map[string]any{"myvar": "secure_val"}
+		// Query param tries to set 'myvar' to 'malicious_val'
+		queryParams := url.Values{"myvar": []string{"malicious_val"}}
+
+		result, err := QueryDashboard(app, ctx, dq, queryParams, variables)
+		assert.NoError(t, err)
+
+		// The second query (result.Sections[1]) should still see 'secure_val'
+		assert.Equal(t, 2, len(result.Sections))
+		assert.Equal(t, "secure_val", result.Sections[1].Queries[0].Rows[0][0], "Secure variable was overwritten by query parameter!")
+	})
+
+	t.Run("Variable precedence - normal query param should still work", func(t *testing.T) {
+		dq := DashboardQuery{
+			Content: `
+				SELECT 'val1'::DROPDOWN AS myvar, 'Val 1'::LABEL AS label UNION ALL SELECT 'val2', 'Val 2';
+				SELECT getvariable('myvar') AS val;
+			`,
+			ID: "test-normal",
+		}
+
+		// No secure variable
+		variables := map[string]any{}
+		// Query param sets 'myvar' to 'val2'
+		queryParams := url.Values{"myvar": []string{"val2"}}
+
+		result, err := QueryDashboard(app, ctx, dq, queryParams, variables)
+		assert.NoError(t, err)
+
+		// The second query should see 'val2'
+		assert.Equal(t, 2, len(result.Sections))
+		assert.Equal(t, "val2", result.Sections[1].Queries[0].Rows[0][0])
 	})
 }

--- a/server/core/stream_query.go
+++ b/server/core/stream_query.go
@@ -803,7 +803,7 @@ func getVarPrefix(app *App, conn *sqlx.Conn, ctx context.Context, sqlQueries []s
 			}
 			columns = append(columns, col)
 		}
-		err = collectVars(singleVars, multiVars, rInfo.Type, queryParams, columns, data)
+		err = collectVars(singleVars, multiVars, variables, rInfo.Type, queryParams, columns, data)
 		if err != nil {
 			return "", "", err
 		}

--- a/server/web/routes.go
+++ b/server/web/routes.go
@@ -247,7 +247,7 @@ func jwtOrAPIKeyMiddleware(app *core.App, jwtMiddleware echo.MiddlewareFunc, set
 		apiKeyChain := keyAuthMiddleware(apiKeyActorMid(next))
 		return func(c echo.Context) error {
 			token := extractAuthorizationToken(c)
-			if core.IsAPIKeyToken(token) || !app.LoginRequired {
+			if core.IsAPIKeyToken(token) || (!app.LoginRequired && token == "") {
 				return apiKeyChain(c)
 			}
 			return jwtChain(c)

--- a/ui/src/routes/new.tsx
+++ b/ui/src/routes/new.tsx
@@ -151,7 +151,7 @@ function NewDashboard () {
     } else {
       // Set default content based on app type
       const defaultContent =
-				appType === "task" ? defaultTaskQuery : defaultDashboardQuery;
+        appType === "task" ? defaultTaskQuery : defaultDashboardQuery;
       setEditorQuery(defaultContent);
       setRunningQuery(defaultContent);
     }
@@ -255,7 +255,7 @@ function NewDashboard () {
   const handleQueryChange = (value: string | undefined) => {
     const newQuery = value || "";
     const currentDefaultQuery =
-			appType === "task" ? defaultTaskQuery : defaultDashboardQuery;
+      appType === "task" ? defaultTaskQuery : defaultDashboardQuery;
 
     // Save to localStorage
     if (newQuery !== currentDefaultQuery && newQuery.trim() !== "") {
@@ -341,7 +341,7 @@ function NewDashboard () {
 
   const handleDiscardChanges = useCallback(() => {
     const defaultContent =
-			appType === "task" ? defaultTaskQuery : defaultDashboardQuery;
+      appType === "task" ? defaultTaskQuery : defaultDashboardQuery;
     editorStorage.clearChanges("new");
     setEditorQuery(defaultContent);
     setRunningQuery(defaultContent);
@@ -355,7 +355,7 @@ function NewDashboard () {
   // Helper to check if content has been modified
   const hasUnsavedChanges = () => {
     const defaultContent =
-			appType === "task" ? defaultTaskQuery : defaultDashboardQuery;
+      appType === "task" ? defaultTaskQuery : defaultDashboardQuery;
     return editorQuery !== defaultContent;
   };
 
@@ -416,7 +416,7 @@ function NewDashboard () {
                 <div className="text-xs text-ctext2 dark:text-dtext2 mt-4 mx-4 opacity-85">
                   {loadDuration ? (
                     <span>
-											Load time:{" "}
+                      Load time:{" "}
                       {loadDuration >= 1000
                         ? `${(loadDuration / 1000).toFixed(2)}s`
                         : `${loadDuration}ms`}
@@ -457,7 +457,7 @@ function NewDashboard () {
                   className="size-4 text-ctext2 dark:text-dtext2 mr-0.5"
                   aria-hidden={true}
                 />
-								New
+                New
                 {systemConfig.tasksEnabled && systemConfig.editEnabled ? (
                   <Select value={appType} onValueChange={handleTypeChange}>
                     <SelectTrigger className="w-36">
@@ -469,14 +469,14 @@ function NewDashboard () {
                           className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 mr-1.5"
                           aria-hidden={true}
                         />
-												Dashboard
+                        Dashboard
                       </SelectItem>
                       <SelectItem value="task">
                         <RiCodeSSlashFill
                           className="size-5 fill-ctext2 dark:fill-dtext2 inline -mt-1 mr-2"
                           aria-hidden={true}
                         />
-												Task
+                        Task
                       </SelectItem>
                     </SelectContent>
                   </Select>
@@ -496,7 +496,7 @@ function NewDashboard () {
                 disabled={!hasUnsavedChanges()}
                 variant="destructive"
               >
-								Discard
+                Discard
               </Button>
             </Tooltip>
             <Tooltip
@@ -510,7 +510,7 @@ function NewDashboard () {
                 variant="secondary"
                 className={cx("my-2", { "ml-2": hasUnsavedChanges(), "ml-4": !hasUnsavedChanges() })}
               >
-								Create
+                Create
               </Button>
             </Tooltip>
             <Tooltip
@@ -524,7 +524,7 @@ function NewDashboard () {
                 isLoading={isPreviewLoading}
                 className="ml-2"
               >
-								Run
+                Run
               </Button>
             </Tooltip>
           </div>
@@ -587,14 +587,14 @@ function NewDashboard () {
                 onClick={() => setShowCreateDialog(false)}
                 variant="secondary"
               >
-								Cancel
+                Cancel
               </Button>
               <Button
                 type="submit"
                 disabled={creating || !dashboardName.trim()}
                 isLoading={creating}
               >
-								Create
+                Create
               </Button>
             </DialogFooter>
           </form>
@@ -606,14 +606,14 @@ function NewDashboard () {
           <DialogHeader>
             <DialogTitle>Discard Changes</DialogTitle>
             <DialogDescription>
-							Are you sure you want to discard your changes and reset to the
-							default content? This action cannot be undone.
+              Are you sure you want to discard your changes and reset to the
+              default content? This action cannot be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button onClick={() => setShowDiscardDialog(false)}>Cancel</Button>
             <Button variant="destructive" onClick={handleDiscardChanges}>
-							Discard
+              Discard
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
This used to work correctly.
Fix it now to work correctly again, including when downloading files.

This is a security issue if you use jwt variables to filter data and have a dashboard variable defined with the exact same name. Usually you don't have that. And even if you do, you can still not set random values via a query param. The backend validates to only allow values that are defined by the SQL.

Anyways, it works all right with this fix now.