### PR TITLE
Init Tasks only from current folder and up when in Memory-Mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,10 +336,7 @@ jobs:
           cd npm-package
           # Use --provenance for OIDC-linked builds.
           # Note: Requires Trusted Publishing setup on npmjs.com.
-          # If still using NPM_TOKEN, it will use that for auth but still generate provenance.
           npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   pypi-publish:
     name: Publish to PyPI

--- a/server/core/app.go
+++ b/server/core/app.go
@@ -222,6 +222,8 @@ func New(
 	return app, nil
 }
 
+const dashboardPathKey contextKey = "dashboardPath"
+
 func (app *App) GetDuckDB(ctx context.Context) (*sqlx.DB, func(), error) {
 	if app.DuckDBDSN != ":memory:" {
 		return app.DuckDB, func() {}, nil
@@ -292,8 +294,18 @@ func (app *App) GetDuckDB(ctx context.Context) (*sqlx.DB, func(), error) {
 			cleanup()
 			return nil, nil, fmt.Errorf("failed to get init tasks: %w", err)
 		}
-		for _, content := range initTasks {
-			res, err := executeTaskOnDB(app, ctx, dbx, content)
+		dashPath, hasDashPath := ctx.Value(dashboardPathKey).(string)
+		for _, task := range initTasks {
+			if hasDashPath {
+				taskPath := "/"
+				if task.Path != nil && *task.Path != "" {
+					taskPath = "/" + *task.Path + "/"
+				}
+				if !strings.HasPrefix(dashPath, taskPath) {
+					continue
+				}
+			}
+			res, err := executeTaskOnDB(app, ctx, dbx, task.Content)
 			if err != nil {
 				app.Logger.WithGroup("tasks").Error("Error running init task on memory db", slog.Any("error", err))
 			} else if !res.Success {

--- a/server/core/get_dashboard.go
+++ b/server/core/get_dashboard.go
@@ -358,6 +358,7 @@ func ValidateDashboardDownload(app *App, ctx context.Context, sourceDashboardId 
 		return false, err
 	}
 
+	ctx = context.WithValue(ctx, dashboardPathKey, dashboard.Path)
 	cleanContent := util.StripSQLComments(dashboard.Content)
 	sqls, err := util.SplitSQLQueries(cleanContent)
 	if err != nil {
@@ -476,6 +477,7 @@ func GetDashboard(app *App, ctx context.Context, dashboardId string, queryParams
 		return GetResult{}, err
 	}
 
+	ctx = context.WithValue(ctx, dashboardPathKey, dashboard.Path)
 	return QueryDashboard(app, ctx, DashboardQuery{
 		Content:    dashboard.Content,
 		ID:         dashboardId,

--- a/server/core/schedule_task.go
+++ b/server/core/schedule_task.go
@@ -29,7 +29,12 @@ type BroadCastPayload struct {
 	Content string `json:"content"`
 }
 
-func GetInitTasks(app *App, ctx context.Context) ([]string, error) {
+type InitTask struct {
+	Content string  `db:"content"`
+	Path    *string `db:"path"`
+}
+
+func GetInitTasks(app *App, ctx context.Context) ([]InitTask, error) {
 	query := `WITH RECURSIVE folder_paths AS (
 			SELECT id, name, CAST(name AS TEXT) as full_path, 0 as depth
 			FROM folders
@@ -40,7 +45,8 @@ func GetInitTasks(app *App, ctx context.Context) ([]string, error) {
 			JOIN folder_paths fp ON f.parent_folder_id = fp.id
 		)
 		SELECT
-			a.content
+			a.content,
+			fp.full_path as path
 		FROM task_runs t
 		JOIN apps a ON a.id = t.task_id
 		LEFT JOIN folder_paths fp ON fp.id = a.folder_id
@@ -51,9 +57,9 @@ func GetInitTasks(app *App, ctx context.Context) ([]string, error) {
 			fp.full_path ASC,
 			a.name ASC`
 
-	var contents []string
-	err := app.Sqlite.SelectContext(ctx, &contents, query)
-	return contents, err
+	var tasks []InitTask
+	err := app.Sqlite.SelectContext(ctx, &tasks, query)
+	return tasks, err
 }
 
 func getNextTaskRun(app *App, ctx context.Context, content string) (*time.Time, string, error) {

--- a/server/core/stream_query.go
+++ b/server/core/stream_query.go
@@ -79,6 +79,7 @@ func StreamQueryCSV(
 	if err != nil {
 		return fmt.Errorf("error getting dashboard: %w", err)
 	}
+	ctx = context.WithValue(ctx, dashboardPathKey, dashboard.Path)
 	cleanContent := util.StripSQLComments(dashboard.Content)
 	sqls, err := util.SplitSQLQueries(cleanContent)
 	if err != nil {
@@ -167,6 +168,7 @@ func StreamQueryJSON(
 	if err != nil {
 		return fmt.Errorf("error getting dashboard: %w", err)
 	}
+	ctx = context.WithValue(ctx, dashboardPathKey, dashboard.Path)
 	cleanContent := util.StripSQLComments(dashboard.Content)
 	sqls, err := util.SplitSQLQueries(cleanContent)
 	if err != nil {
@@ -415,6 +417,7 @@ func StreamQueryXLSX(
 	if err != nil {
 		return fmt.Errorf("error getting dashboard: %w", err)
 	}
+	ctx = context.WithValue(ctx, dashboardPathKey, dashboard.Path)
 	cleanContent := util.StripSQLComments(dashboard.Content)
 	sqls, err := util.SplitSQLQueries(cleanContent)
 	if err != nil {

--- a/server/core/task_init_test.go
+++ b/server/core/task_init_test.go
@@ -186,3 +186,125 @@ func TestScheduleExistingInitTasks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exists)
 }
+
+func TestGetDuckDBMemoryModeFolderFiltering(t *testing.T) {
+	app, cleanup := setupTestApp(t)
+	defer cleanup()
+
+	// Switch to :memory: mode for testing
+	app.DuckDBDSN = ":memory:"
+
+	ctx := context.Background()
+
+	// 1. Create folders
+	// Root is parent_folder_id = nil.
+	// /Marketing
+	marketingFolderID := "f_marketing"
+	_, err := app.Sqlite.Exec(`INSERT INTO folders (id, name, created_at, updated_at) VALUES (?, ?, datetime('now'), datetime('now'))`, marketingFolderID, "Marketing")
+	assert.NoError(t, err)
+
+	// /Sales
+	salesFolderID := "f_sales"
+	_, err = app.Sqlite.Exec(`INSERT INTO folders (id, name, created_at, updated_at) VALUES (?, ?, datetime('now'), datetime('now'))`, salesFolderID, "Sales")
+	assert.NoError(t, err)
+
+	// /Marketing/Campaigns
+	campaignsFolderID := "f_campaigns"
+	_, err = app.Sqlite.Exec(`INSERT INTO folders (id, name, parent_folder_id, created_at, updated_at) VALUES (?, ?, ?, datetime('now'), datetime('now'))`, campaignsFolderID, "Campaigns", marketingFolderID)
+	assert.NoError(t, err)
+
+	// 2. Create init tasks in SQLite
+	// Root task (folder_id = nil)
+	_, err = app.Sqlite.Exec(`INSERT INTO apps (id, type, name, content, created_at, updated_at) VALUES (?, 'task', 'root_task', ?, datetime('now'), datetime('now'))`, "t_root", "SELECT 'init'::SCHEDULE; CREATE TABLE root_table (val INT);")
+	assert.NoError(t, err)
+	_, err = app.Sqlite.Exec(`INSERT INTO task_runs (task_id, next_run_type) VALUES (?, 'init')`, "t_root")
+	assert.NoError(t, err)
+
+	// Marketing task
+	_, err = app.Sqlite.Exec(`INSERT INTO apps (id, type, folder_id, name, content, created_at, updated_at) VALUES (?, 'task', ?, 'marketing_task', ?, datetime('now'), datetime('now'))`, "t_marketing", marketingFolderID, "SELECT 'init'::SCHEDULE; CREATE TABLE marketing_table (val INT);")
+	assert.NoError(t, err)
+	_, err = app.Sqlite.Exec(`INSERT INTO task_runs (task_id, next_run_type) VALUES (?, 'init')`, "t_marketing")
+	assert.NoError(t, err)
+
+	// Campaigns task
+	_, err = app.Sqlite.Exec(`INSERT INTO apps (id, type, folder_id, name, content, created_at, updated_at) VALUES (?, 'task', ?, 'campaigns_task', ?, datetime('now'), datetime('now'))`, "t_campaigns", campaignsFolderID, "SELECT 'init'::SCHEDULE; CREATE TABLE campaigns_table (val INT);")
+	assert.NoError(t, err)
+	_, err = app.Sqlite.Exec(`INSERT INTO task_runs (task_id, next_run_type) VALUES (?, 'init')`, "t_campaigns")
+	assert.NoError(t, err)
+
+	// Sales task
+	_, err = app.Sqlite.Exec(`INSERT INTO apps (id, type, folder_id, name, content, created_at, updated_at) VALUES (?, 'task', ?, 'sales_task', ?, datetime('now'), datetime('now'))`, "t_sales", salesFolderID, "SELECT 'init'::SCHEDULE; CREATE TABLE sales_table (val INT);")
+	assert.NoError(t, err)
+	_, err = app.Sqlite.Exec(`INSERT INTO task_runs (task_id, next_run_type) VALUES (?, 'init')`, "t_sales")
+	assert.NoError(t, err)
+
+	// Helper to check table existence
+	checkTableExists := func(db *sqlx.DB, tableName string) bool {
+		var exists int
+		err := db.Get(&exists, "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = ?", tableName)
+		if err != nil {
+			return false
+		}
+		return exists > 0
+	}
+
+	t.Run("Case A: dashboard in /Marketing/", func(t *testing.T) {
+		testCtx := context.WithValue(ctx, dashboardPathKey, "/Marketing/")
+		db, dbCleanup, err := app.GetDuckDB(testCtx)
+		assert.NoError(t, err)
+		defer dbCleanup()
+
+		assert.True(t, checkTableExists(db, "root_table"))
+		assert.True(t, checkTableExists(db, "marketing_table"))
+		assert.False(t, checkTableExists(db, "campaigns_table"))
+		assert.False(t, checkTableExists(db, "sales_table"))
+	})
+
+	t.Run("Case B: dashboard in /Marketing/Campaigns/", func(t *testing.T) {
+		testCtx := context.WithValue(ctx, dashboardPathKey, "/Marketing/Campaigns/")
+		db, dbCleanup, err := app.GetDuckDB(testCtx)
+		assert.NoError(t, err)
+		defer dbCleanup()
+
+		assert.True(t, checkTableExists(db, "root_table"))
+		assert.True(t, checkTableExists(db, "marketing_table"))
+		assert.True(t, checkTableExists(db, "campaigns_table"))
+		assert.False(t, checkTableExists(db, "sales_table"))
+	})
+
+	t.Run("Case C: dashboard in /", func(t *testing.T) {
+		testCtx := context.WithValue(ctx, dashboardPathKey, "/")
+		db, dbCleanup, err := app.GetDuckDB(testCtx)
+		assert.NoError(t, err)
+		defer dbCleanup()
+
+		assert.True(t, checkTableExists(db, "root_table"))
+		assert.False(t, checkTableExists(db, "marketing_table"))
+		assert.False(t, checkTableExists(db, "campaigns_table"))
+		assert.False(t, checkTableExists(db, "sales_table"))
+	})
+
+	t.Run("Case D: dashboard in /Sales/", func(t *testing.T) {
+		testCtx := context.WithValue(ctx, dashboardPathKey, "/Sales/")
+		db, dbCleanup, err := app.GetDuckDB(testCtx)
+		assert.NoError(t, err)
+		defer dbCleanup()
+
+		assert.True(t, checkTableExists(db, "root_table"))
+		assert.False(t, checkTableExists(db, "marketing_table"))
+		assert.False(t, checkTableExists(db, "campaigns_table"))
+		assert.True(t, checkTableExists(db, "sales_table"))
+	})
+
+	t.Run("Case E: no dashboard path context (run all)", func(t *testing.T) {
+		db, dbCleanup, err := app.GetDuckDB(ctx)
+		assert.NoError(t, err)
+		defer dbCleanup()
+
+		assert.True(t, checkTableExists(db, "root_table"))
+		assert.True(t, checkTableExists(db, "marketing_table"))
+		assert.True(t, checkTableExists(db, "campaigns_table"))
+		assert.True(t, checkTableExists(db, "sales_table"))
+	})
+}
+


### PR DESCRIPTION
When DuckDB is initialized we run the configured init-sql and we also run SQL from all init tasks recursively.
Normally we do this only once when the application is starting up.
But when duckdb is set to `:memory:`, we use a new duckdb database for every request.
In that case we run the mentioned SQL every time a new duckdb in-memory database is initialized.
Now we change that when in memory-mode we don't run all init tasks, but only the init tasks in the same folder or folders above relative to the dashboard itself.