### PR TITLE
Disable dashboard fetch retry for temporary dashboards

### DIFF
--- a/ui/src/components/SearchBar.tsx
+++ b/ui/src/components/SearchBar.tsx
@@ -182,22 +182,15 @@ export function SearchBar () {
     }
   };
 
-  // Track previous query to detect mode switches
-  const prevQueryRef = useRef(query);
-  const prevIsActiveRef = useRef(isActive);
-
+  // Keep selectedIndex in sync with the first item when items change
   useEffect(() => {
-    // Only auto-select when dropdown opens or when switching between search/recent modes
-    const justOpened = isActive && !prevIsActiveRef.current;
-    const modeSwitched = isActive && (!!query !== !!prevQueryRef.current);
-
-    if (justOpened || modeSwitched) {
-      const items = query ? searchResults : recentApps;
-      setSelectedIndex(items.length > 0 ? 0 : -1);
+    if (!isActive) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSelectedIndex(-1);
+      return;
     }
-
-    prevQueryRef.current = query;
-    prevIsActiveRef.current = isActive;
+    const items = query ? searchResults : recentApps;
+    setSelectedIndex(items.length > 0 ? 0 : -1);
   }, [query, isActive, searchResults, recentApps]);
 
   if (!isActive) {

--- a/ui/src/components/dashboard/index.tsx
+++ b/ui/src/components/dashboard/index.tsx
@@ -731,13 +731,14 @@ const fetchDashboard = async (
 ): Promise<Result> => {
   const jwt = await getJwt();
   const searchParams = getSearchParamString(vars);
+  const isTemporary = id.startsWith("shaper-tmp.");
   const res = await fetchWithRetry(`${baseUrl}api/dashboards/${id}?${searchParams}`, {
     headers: {
       "Content-Type": "application/json",
       Authorization: jwt,
     },
     signal,
-  });
+  }, isTemporary ? { maxRetries: 0 } : undefined);
   const json = await res.json();
   if (res.status !== 200) {
     throw new Error(


### PR DESCRIPTION
By not waiting and retrying to load dashbaords on errors
for temporary dashboards, we show error directly when developing them.
This affect the new and edit views and also when developing dashboards
via `shaper dev`.