### PR TITLE
Ensures DuckDB version is compatible with Motherduck

### DIFF
--- a/server/util/duckdb_version_test.go
+++ b/server/util/duckdb_version_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package util
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"golang.org/x/mod/semver"
+)
+
+type MotherDuckVersions struct {
+	DuckDB struct {
+		MotherDuckRegions map[string]struct {
+			Min string `json:"min"`
+			Max string `json:"max"`
+		} `json:"motherduck_regions"`
+	} `json:"duckdb"`
+}
+
+func TestMotherDuckCompatibility(t *testing.T) {
+	// 1. Get our DuckDB version
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("failed to open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	var ourVersion string
+	err = db.QueryRow("SELECT version()").Scan(&ourVersion)
+	if err != nil {
+		t.Fatalf("failed to query version: %v", err)
+	}
+
+	// Ensure our version has the 'v' prefix for semver comparison
+	if len(ourVersion) > 0 && ourVersion[0] != 'v' {
+		ourVersion = "v" + ourVersion
+	}
+
+	t.Logf("Our DuckDB version: %s", ourVersion)
+
+	// 2. Fetch MotherDuck supported versions
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("https://motherduck.com/docs/duckdb-versions.json")
+	if err != nil {
+		if os.Getenv("CI") == "true" {
+			t.Fatalf("Failed to fetch MotherDuck versions JSON in CI: %v", err)
+		}
+		t.Skipf("Skipping compatibility check; failed to fetch MotherDuck versions: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if os.Getenv("CI") == "true" {
+			t.Fatalf("MotherDuck versions endpoint returned status %d", resp.StatusCode)
+		}
+		t.Skipf("Skipping compatibility check; endpoint returned status %d", resp.StatusCode)
+	}
+
+	var mdVersions MotherDuckVersions
+	if err := json.NewDecoder(resp.Body).Decode(&mdVersions); err != nil {
+		t.Fatalf("failed to decode MotherDuck versions JSON: %v", err)
+	}
+
+	// Get global region compatibility range
+	global, exists := mdVersions.DuckDB.MotherDuckRegions["global"]
+	if !exists {
+		t.Fatalf("global region not found in MotherDuck versions JSON")
+	}
+
+	minVersion := "v" + global.Min
+	maxVersion := "v" + global.Max
+
+	t.Logf("MotherDuck supported range (global): %s to %s", minVersion, maxVersion)
+
+	// Check if our version is within range
+	// semver.Compare(v, w) returns:
+	//   -1 if v < w
+	//    0 if v == w
+	//   +1 if v > w
+	if semver.Compare(ourVersion, minVersion) < 0 {
+		t.Errorf("Incompatible DuckDB version: our version %s is older than the minimum supported MotherDuck version %s", ourVersion, minVersion)
+	} else if semver.Compare(ourVersion, maxVersion) > 0 {
+		t.Errorf("Incompatible DuckDB version: our version %s is newer than the maximum supported MotherDuck version %s", ourVersion, maxVersion)
+	} else {
+		t.Logf("DuckDB version %s is fully compatible with MotherDuck!", ourVersion)
+	}
+}

--- a/ui/src/components/providers/MenuProvider.tsx
+++ b/ui/src/components/providers/MenuProvider.tsx
@@ -29,7 +29,7 @@ import { SearchBar } from "../SearchBar";
 const isLg = () => window.innerWidth >= 1024;
 const MENU_STATE_KEY = "shaper-menu-open";
 
-export function MenuProvider ({
+export function MenuProvider({
   children,
   isHome = false,
   isAdmin = false,
@@ -245,8 +245,8 @@ export function MenuProvider ({
                         "underline cursor-default": isSettings,
                       })}
                     >
-                      <RiSettings4Line className="size-4" />
-                      Settings
+                      <RiAdminLine className="size-4" />
+                      Profile
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem disabled={isAdmin} className="mt-1">
@@ -256,8 +256,8 @@ export function MenuProvider ({
                         "underline cursor-default": isAdmin,
                       })}
                     >
-                      <RiAdminLine className="size-4" />
-                      Admin
+                      <RiSettings4Line className="size-4" />
+                      Admin Settings
                     </Link>
                   </DropdownMenuItem>
 

--- a/ui/src/components/providers/MenuProvider.tsx
+++ b/ui/src/components/providers/MenuProvider.tsx
@@ -29,7 +29,7 @@ import { SearchBar } from "../SearchBar";
 const isLg = () => window.innerWidth >= 1024;
 const MENU_STATE_KEY = "shaper-menu-open";
 
-export function MenuProvider({
+export function MenuProvider ({
   children,
   isHome = false,
   isAdmin = false,

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/admin")({
   component: Admin,
 });
 
-function Admin() {
+function Admin () {
   const location = useLocation();
   const queryApi = useQueryApi();
   const [version, setVersion] = useState<string | null>(null);

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -5,7 +5,7 @@ import { Helmet } from "react-helmet";
 import { Tabs, TabsList, TabsTrigger } from "../components/tremor/Tabs";
 import { MenuProvider } from "../components/providers/MenuProvider";
 import { MenuTrigger } from "../components/MenuTrigger";
-import { RiAdminLine } from "@remixicon/react";
+import { RiSettings4Line } from "@remixicon/react";
 import { useQueryApi } from "../hooks/useQueryApi";
 import { useEffect, useState } from "react";
 
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/admin")({
   component: Admin,
 });
 
-function Admin () {
+function Admin() {
   const location = useLocation();
   const queryApi = useQueryApi();
   const [version, setVersion] = useState<string | null>(null);
@@ -41,7 +41,7 @@ function Admin () {
   return (
     <MenuProvider isAdmin>
       <Helmet>
-        <title>Admin</title>
+        <title>Admin Settings</title>
         <meta name="description" content="Admin Settings" />
       </Helmet>
 
@@ -49,8 +49,8 @@ function Admin () {
         <div className="flex">
           <MenuTrigger className="pr-1.5 py-3 -ml-1.5" />
           <h1 className="font-semibold font-display flex-grow pb-4 pt-3.5">
-            <RiAdminLine className="size-4 inline ml-1 mr-1 -mt-1" />
-            Admin
+            <RiSettings4Line className="size-4 inline ml-1 mr-1 -mt-1" />
+            Admin Settings
           </h1>
         </div>
 

--- a/ui/src/routes/settings.tsx
+++ b/ui/src/routes/settings.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/settings")({
   component: Settings,
 });
 
-function Settings() {
+function Settings () {
   const navigate = useNavigate();
   const { toast } = useToast();
   const queryApi = useQueryApi();

--- a/ui/src/routes/settings.tsx
+++ b/ui/src/routes/settings.tsx
@@ -9,7 +9,7 @@ import { Label } from "../components/tremor/Label";
 import { useToast } from "../hooks/useToast";
 import { MenuProvider } from "../components/providers/MenuProvider";
 import { MenuTrigger } from "../components/MenuTrigger";
-import { RiSettings4Line } from "@remixicon/react";
+import { RiAdminLine } from "@remixicon/react";
 import { useQueryApi } from "../hooks/useQueryApi";
 import { useAuth } from "../lib/auth";
 import { useEffect } from "react";
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/settings")({
   component: Settings,
 });
 
-function Settings () {
+function Settings() {
   const navigate = useNavigate();
   const { toast } = useToast();
   const queryApi = useQueryApi();
@@ -108,15 +108,15 @@ function Settings () {
   return (
     <MenuProvider isSettings>
       <Helmet>
-        <title>Settings</title>
+        <title>User Settings</title>
       </Helmet>
 
       <div className="px-3 pb-3 min-h-dvh flex flex-col">
         <div className="flex">
           <MenuTrigger className="pr-1.5 py-3 -ml-1.5" />
           <h1 className="font-semibold font-display flex-grow pb-4 pt-3.5">
-            <RiSettings4Line className="size-4 inline ml-1 mr-1 -mt-1" />
-            Settings
+            <RiAdminLine className="size-4 inline ml-1 mr-1 -mt-1" />
+            User Settings
           </h1>
         </div>
 


### PR DESCRIPTION
Only update DuckDB if new version is already supported by Motherduck.

We are using a json endpoint Motherduck provides for this to check their
supported version.